### PR TITLE
fix: remove account balance approximate

### DIFF
--- a/src/components/AccountDetailsPanel.vue
+++ b/src/components/AccountDetailsPanel.vue
@@ -34,7 +34,7 @@
             Balance
           </th>
           <td class="account-details-panel__data">
-            {{ formatAePrice(accountDetails.balance) }}
+            {{ formatAePrice(accountDetails.balance, null) }}
           </td>
         </tr>
         <tr class="account-details-panel__row">


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Resolves #97 

Removes approximating from account balance value in account details

## Demo
![image](https://user-images.githubusercontent.com/46789227/232787049-4b94fac0-82f1-44f4-902b-d268db8700cc.png)
![image](https://user-images.githubusercontent.com/46789227/232787196-02957bdb-4c1c-490a-86a6-209a8bc2c190.png)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does NOT require a change to the documentation.
