### PR TITLE
feat: move more content to rendering on the server-side

### DIFF
--- a/src/components/AppHero.vue
+++ b/src/components/AppHero.vue
@@ -14,10 +14,8 @@
           <the-search-bar class="hero__search-bar"/>
         </div>
       </div>
-      <client-only>
-        <market-stats class="hero__market-stats"/>
-        <stats-panel/>
-      </client-only>
+      <market-stats class="hero__market-stats"/>
+      <stats-panel/>
     </div>
   </div>
 </template>

--- a/src/components/TokenDetailsPanel.vue
+++ b/src/components/TokenDetailsPanel.vue
@@ -28,9 +28,7 @@
             Price
           </th>
           <td class="token-details-panel__data">
-            <client-only>
-              {{ fiatPrice }} ({{ formatAePrice(tokenDetails.price) }})
-            </client-only>
+            {{ fiatPrice }} ({{ formatAePrice(tokenDetails.price) }})
           </td>
         </tr>
         <tr
@@ -40,9 +38,7 @@
             Market cap
           </th>
           <td class="token-details-panel__data">
-            <client-only>
-              {{ marketCap }}
-            </client-only>
+            {{ marketCap }}
           </td>
         </tr>
         <tr class="token-details-panel__row">

--- a/src/components/TokensPanel.vue
+++ b/src/components/TokensPanel.vue
@@ -44,7 +44,7 @@ async function loadNextTokens() {
 const limit = computed(() => process.client && isDesktop() ? 10 : 3)
 
 if (process.client) {
-  await fetchTokens(`/v2/aex9?by=name&direction=forward&limit=${limit.value}`)
+  fetchTokens(`/v2/aex9?by=name&direction=forward&limit=${limit.value}`)
 }
 
 </script>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -39,9 +39,7 @@
             The æternity blockchain supports protocol-level .chain names via the
             æternity naming system (AENS).
           </div>
-          <client-only>
-            <names-panel/>
-          </client-only>
+          <names-panel/>
         </div>
         <div class="dashboard__column">
           <h2 class="dashboard__heading">
@@ -51,9 +49,7 @@
             .chain names can be obtained either immediately or via an auction
             process, if shorter than 13 characters.
           </div>
-          <client-only>
-            <auctions-panel>Auctions ending soon</auctions-panel>
-          </client-only>
+          <auctions-panel>Auctions ending soon</auctions-panel>
         </div>
       </div>
 
@@ -72,9 +68,7 @@
               Learn more
             </app-link>
           </div>
-          <client-only>
-            <state-channels-panel class="dashboard__state-channels-panel"/>
-          </client-only>
+          <state-channels-panel class="dashboard__state-channels-panel"/>
         </div>
       </div>
     </div>
@@ -89,25 +83,32 @@ import StateChannelsPanel from '@/components/StateChannelsPanel'
 import AppHero from '@/components/AppHero'
 import AppLink from '@/components/AppLink'
 
-if (process.client) {
-  const {
-    fetchSelectedMicroblocksInfo,
-    fetchDeltaStats,
-  } = useRecentBlocksStore()
-  const { fetchBlockchainStats } = useBlockchainStatsStore()
-  const { fetchStateChannels } = useStateChannelsStore()
-  const { fetchInAuctionNames, fetchRecentlyActivatedNames } = useNamesStore()
+const {
+  fetchSelectedMicroblocksInfo,
+  fetchDeltaStats,
+} = useRecentBlocksStore()
+const {
+  fetchTotalStats,
+  fetchMaxTps,
+  fetchTotalTransactionsCount,
+} = useBlockchainStatsStore()
+const { fetchStateChannels } = useStateChannelsStore()
+const { fetchInAuctionNames, fetchRecentlyActivatedNames } = useNamesStore()
 
-  // fetch client-side only due to very dynamic nature of the data and limit difference depending on desktop/mobile view
-  await useAsyncData(() => Promise.all([
-    fetchStateChannels(),
-    fetchInAuctionNames(),
-    fetchRecentlyActivatedNames(),
-    fetchSelectedMicroblocksInfo(),
-    fetchBlockchainStats(),
-    fetchDeltaStats(),
-  ]))
-}
+await useAsyncData(() => Promise.all([
+  fetchStateChannels(),
+  fetchInAuctionNames(),
+  fetchRecentlyActivatedNames(),
+  fetchTotalStats(),
+  fetchMaxTps(),
+]))
+
+// fetch client-side only due to very dynamic nature of the data and limit difference depending on desktop/mobile view
+await useAsyncData(() => Promise.all([
+  fetchSelectedMicroblocksInfo(),
+  fetchTotalTransactionsCount(),
+  fetchDeltaStats(),
+]), { server: false })
 </script>
 
 <style scoped>

--- a/src/stores/blockchainStats.js
+++ b/src/stores/blockchainStats.js
@@ -17,13 +17,6 @@ export const useBlockchainStatsStore = defineStore('blockchainStats', {
     burnedCount: null,
   }),
   actions: {
-    fetchBlockchainStats() {
-      return Promise.all([
-        this.fetchTotalStats(),
-        this.fetchMaxTps(),
-        this.fetchTotalTransactionsCount(),
-      ])
-    },
     async fetchTotalStats() {
       const { data } = await axios.get(`${useRuntimeConfig().public.MIDDLEWARE_URL}/v2/totalstats?limit=1`)
       const lastBlock = data.data[0]

--- a/src/stores/contractDetails.js
+++ b/src/stores/contractDetails.js
@@ -15,14 +15,16 @@ export const useContractDetailsStore = defineStore('contractDetails', {
     rawContractCallTransactions: null,
   }),
   actions: {
-    fetchContractDetails(contractId) {
+    async fetchContractDetails(contractId) {
       this.contractId = contractId
-      return Promise.allSettled([
+      await Promise.allSettled([
         this.fetchContractInformation(),
         this.fetchContractCallsCount(),
         this.fetchContractCreationTx(),
         this.fetchContractType(),
       ])
+
+      return true
     },
     async fetchContractInformation() {
       this.rawContractInformation = null


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Resolves #58 

* Much more content is now rendered on the server-side rather than client-side
* fixes some unrelated SSR issues I faced when testing the app:

when visiting contract details page:
![image](https://user-images.githubusercontent.com/46789227/233067373-200214d8-8bdf-4614-93dc-31cf262489e4.png)

when visiting tokens page:
![image](https://user-images.githubusercontent.com/46789227/233067635-0914fec2-c478-4fe6-8fc9-ec6d420abd0c.png)


## Demo
Before:
![image](https://user-images.githubusercontent.com/46789227/233070225-4e170033-f216-41b2-98fd-3b06cf32c7ec.png)
![image](https://user-images.githubusercontent.com/46789227/233070849-f4a9fb4d-6209-43a8-a150-0eff5182498b.png)

After:
![image](https://user-images.githubusercontent.com/46789227/233070140-1944aa94-cb4a-4759-84e4-dfc9a8ced1b3.png)
![image](https://user-images.githubusercontent.com/46789227/233070775-9ebc05a1-c481-4fe8-acf0-5f846e00b8b0.png)

Naturally, it takes a little bit longer to execute a few additional requests on the server-side but this will be mostly countered by cache (which is not configured for previews). The same requests would normally have to be executed on the client-side so it's saving the time to get the content anyway, regardless of the cache,

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does NOT require a change to the documentation.
