### PR TITLE
fix: handle name history api errors

### DIFF
--- a/src/pages/names/[name].vue
+++ b/src/pages/names/[name].vue
@@ -15,7 +15,7 @@
         v-if="hasCustomPanel"
         class="name-details__panel"/>
       <app-tabs
-        v-if="hasNameHistory"
+        v-if="hasNameHistory && !!nameActions"
         class="name-details__tabs">
         <app-tab title="History">
           <name-history-panel class="name-details__history"/>
@@ -38,7 +38,7 @@ import NamePointersCustomPanel from '@/components/NamePointersCustomPanel'
 import { isDesktop } from '@/utils/screen'
 
 const nameDetailsStore = useNameDetailsStore()
-const { name, nameHash, hasNameHistory } = storeToRefs(nameDetailsStore)
+const { name, nameHash, hasNameHistory, nameActions } = storeToRefs(nameDetailsStore)
 const {
   fetchName,
   fetchNameActions,


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Resolves #127 

Doesn't show the name history tab if loading failed.

I decided to go this path rather than displaying "There is no data available" because so far we have been showing that message when there is no data available in the blockchain. In this case there always is data but fetching it fails. I think it should be handled differently (e.g. some appropriate message that loading data failed, please try again later). Probably will be improved everywhere across the application in #95 

## Demo
![image](https://user-images.githubusercontent.com/46789227/235411651-7273e0a5-93ad-4661-b8d1-f657ea775d6d.png)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does NOT require a change to the documentation.
