### PR TITLE
feat: refactor transaction details to use Composition API

### DIFF
--- a/src/components/TransactionGeneralPanel.vue
+++ b/src/components/TransactionGeneralPanel.vue
@@ -124,7 +124,7 @@
   </app-panel>
 </template>
 
-<script>
+<script setup>
 import AppPanel from '@/components/AppPanel'
 import AppChip from '@/components/AppChip'
 import AppIcon from '@/components/AppIcon'
@@ -133,42 +133,22 @@ import CopyChip from '@/components/CopyChip'
 import { formatAePrice, formatAettosToAe, formatEllipseHash } from '@/utils/format'
 import DatetimeLabel from '@/components/DatetimeLabel'
 
-export default {
-  name: 'TransactionGeneralPanel',
-  components: {
-    DatetimeLabel,
-    AppLink,
-    AppIcon,
-    AppChip,
-    AppPanel,
-    CopyChip,
-  },
+const { NODE_URL, MIDDLEWARE_URL } = useRuntimeConfig().public
 
-  props: {
-    transactionDetails: {
-      type: Object,
-      required: true,
-    },
+const props = defineProps({
+  transactionDetails: {
+    type: Object,
+    required: true,
   },
-  data: () => ({
-    generation: null,
-    maxHeight: null,
-    currentKeyblockHeight: null,
-  }),
-  computed: {
-    transactionNodeUrl() {
-      return `${this.$config.public.NODE_URL}/v3/transactions/${this.transactionDetails.hash}`
-    },
-    transactionMiddlewareUrl() {
-      return `${this.$config.public.MIDDLEWARE_URL}/v2/txs/${this.transactionDetails.hash}`
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatEllipseHash,
-  },
-}
+})
+
+const transactionNodeUrl = computed(() => {
+  return `${NODE_URL}/v3/transactions/${props.transactionDetails.hash}`
+})
+
+const transactionMiddlewareUrl = computed(() => {
+  return `${MIDDLEWARE_URL}/v2/txs/${props.transactionDetails.hash}`
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionPointersPanel.vue
+++ b/src/components/TransactionPointersPanel.vue
@@ -68,36 +68,25 @@
   </app-panel>
 </template>
 
-<script>
+<script setup>
 import AppPanel from '@/components/AppPanel'
 import { formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionPointersPanel',
-  components: {
-    AppPanel,
+const props = defineProps({
+  transactionData: {
+    type: Object,
+    required: true,
   },
-  props: {
-    transactionData: {
-      type: Object,
-      required: true,
-    },
-  },
-  computed: {
-    pointers() {
-      return this.transactionData.pointers.reduce(
-        (accumulator, pointer) => ({
-          ...accumulator,
-          [pointer.key]: pointer.id,
-        }),
-        {},
-      )
-    },
-  },
-  methods: {
-    formatNullable,
-  },
-}
+})
+const pointers = computed(() => {
+  return props.transactionData.pointers.reduce(
+    (accumulator, pointer) => ({
+      ...accumulator,
+      [pointer.key]: pointer.id,
+    }),
+    {},
+  )
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypePanel.vue
+++ b/src/components/TransactionTypePanel.vue
@@ -42,9 +42,9 @@
   </app-panel>
 </template>
 
-<script>
+<script setup>
 import { defineAsyncComponent } from 'vue'
-import { mapActions, mapState } from 'pinia'
+import { storeToRefs } from 'pinia'
 import AppPanel from '@/components/AppPanel'
 import AppChip from '@/components/AppChip'
 import AppLink from '@/components/AppLink'
@@ -52,51 +52,40 @@ import CopyChip from '@/components/CopyChip'
 import { formatEllipseHash } from '@/utils/format'
 import { useTransactionDetailsStore } from '@/stores/transactionDetails'
 
-export default {
-  name: 'TransactionTypePanel',
-  components: {
-    CopyChip,
-    AppLink,
-    AppChip,
-    AppPanel,
+const props = defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  computed: {
-    ...mapState(useTransactionDetailsStore, ['contractId']),
-    innerTransactionDetails() {
-      return this.transactionData.tx.tx
-    },
-    transactionTypeTableComponent() {
-      return defineAsyncComponent(() =>
-        import(`@/components/TransactionTypeTable${this.transactionData.type}.vue`),
-      )
-    },
-    typeName() {
-      return this.transactionData.type
-        .replace(/([A-Z]+)/g, ' $1').replace(/([A-Z][a-z])/g, ' $1')
-        .toUpperCase()
-    },
-  },
-  watch: {
-    transactionData: {
-      immediate: true,
-      handler() {
-        if (this.transactionData.ga_id) {
-          this.fetchContractIdByAccountId(this.transactionData.ga_id)
-        }
-      },
-    },
-  },
-  methods: {
-    ...mapActions(useTransactionDetailsStore, ['fetchContractIdByAccountId']),
-    formatEllipseHash,
-  },
-}
+})
+
+const transactionDetailsStore = useTransactionDetailsStore()
+const { fetchContractIdByAccountId } = transactionDetailsStore
+const { contractId } = storeToRefs(transactionDetailsStore)
+
+const innerTransactionDetails = computed(() =>
+  props.transactionData.tx.tx,
+)
+
+const transactionTypeTableComponent = computed(() =>
+  defineAsyncComponent(() =>
+    import(`@/components/TransactionTypeTable${props.transactionData.type}.vue`),
+  ),
+)
+
+const typeName = computed(() =>
+  props.transactionData.type
+    .replace(/([A-Z]+)/g, ' $1').replace(/([A-Z][a-z])/g, ' $1')
+    .toUpperCase(),
+)
+
+watch(props.transactionData, () => {
+  if (props.transactionData.ga_id) {
+    fetchContractIdByAccountId(props.transactionData.ga_id)
+  }
+},
+{ immediate: true },
+)
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeStatusLabel.vue
+++ b/src/components/TransactionTypeStatusLabel.vue
@@ -9,23 +9,14 @@
   </template>
 </template>
 
-<script>
+<script setup>
 import AppChip from '@/components/AppChip'
 import { formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeStatusLabel',
-  components: {
-    AppChip,
+defineProps({
+  status: {
+    type: String,
+    default: null,
   },
-  props: {
-    status: {
-      type: String,
-      default: null,
-    },
-  },
-  methods: {
-    formatNullable,
-  },
-}
+})
 </script>

--- a/src/components/TransactionTypeTableChannelCloseMutualTx.vue
+++ b/src/components/TransactionTypeTableChannelCloseMutualTx.vue
@@ -57,26 +57,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatAePrice, formatAettosToAe } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableChannelCloseMutualTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableChannelCloseSoloTx.vue
+++ b/src/components/TransactionTypeTableChannelCloseSoloTx.vue
@@ -51,21 +51,15 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 
-export default {
-  name: 'TransactionTypeTableChannelCloseSoloTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableChannelCreateTx.vue
+++ b/src/components/TransactionTypeTableChannelCreateTx.vue
@@ -84,27 +84,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatAePrice, formatAettosToAe, formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableChannelCreateTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatNullable,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableChannelDepositTx.vue
+++ b/src/components/TransactionTypeTableChannelDepositTx.vue
@@ -37,26 +37,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatAePrice, formatAettosToAe } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableChannelDepositTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableChannelForceProgressTx.vue
+++ b/src/components/TransactionTypeTableChannelForceProgressTx.vue
@@ -56,21 +56,15 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 
-export default {
-  name: 'TransactionTypeTableChannelForceProgressTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableChannelSettleTx.vue
+++ b/src/components/TransactionTypeTableChannelSettleTx.vue
@@ -57,26 +57,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatAePrice, formatAettosToAe } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableChannelSettleTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableChannelSlashTx.vue
+++ b/src/components/TransactionTypeTableChannelSlashTx.vue
@@ -31,21 +31,15 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 
-export default {
-  name: 'TransactionTypeTableChannelSlashTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableChannelSnapshotSoloTx.vue
+++ b/src/components/TransactionTypeTableChannelSnapshotSoloTx.vue
@@ -51,21 +51,15 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 
-export default {
-  name: 'TransactionTypeTableChannelSnapshotSoloTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableChannelWithdrawTx.vue
+++ b/src/components/TransactionTypeTableChannelWithdrawTx.vue
@@ -41,26 +41,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatAePrice, formatAettosToAe } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableChannelWithdrawTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableContractCallTx.vue
+++ b/src/components/TransactionTypeTableContractCallTx.vue
@@ -97,36 +97,22 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import TransactionTypeStatusLabel from '@/components/TransactionTypeStatusLabel'
 import { formatAePrice, formatAettosToAe, formatNullable } from '@/utils/format'
 import AppChip from '@/components/AppChip'
 
-export default {
-  name: 'TransactionTypeTableContractCallTx',
-  components: {
-    AppChip,
-    AppLink,
-    TransactionTypeStatusLabel,
+const props = defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  computed: {
-    gasCosts() {
-      return this.transactionData.gas_used * this.transactionData.gas_price
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatNullable,
-  },
-}
+})
+
+const gasCosts = computed(() =>
+  props.transactionData.gas_used * props.transactionData.gas_price,
+)
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableContractCreateTx.vue
+++ b/src/components/TransactionTypeTableContractCreateTx.vue
@@ -79,34 +79,21 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import TransactionTypeStatusLabel from '@/components/TransactionTypeStatusLabel'
 import { formatAePrice, formatAettosToAe, formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableContractCreateTx',
-  components: {
-    AppLink,
-    TransactionTypeStatusLabel,
+const props = defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  computed: {
-    gasCosts() {
-      return this.transactionData.gas_used * this.transactionData.gas_price
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatNullable,
-  },
-}
+})
+
+const gasCosts = computed(() =>
+  props.transactionData.gas_used * props.transactionData.gas_price,
+)
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableGAAttachTx.vue
+++ b/src/components/TransactionTypeTableGAAttachTx.vue
@@ -77,34 +77,21 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import TransactionTypeStatusLabel from '@/components/TransactionTypeStatusLabel'
 import { formatAePrice, formatAettosToAe, formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableGAAttachTx',
-  components: {
-    AppLink,
-    TransactionTypeStatusLabel,
+const props = defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  computed: {
-    gasCosts() {
-      return this.transactionData.gas_used * this.transactionData.gas_price
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatNullable,
-  },
-}
+})
+
+const gasCosts = computed(() =>
+  props.transactionData.gas_used * props.transactionData.gas_price,
+)
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableGAMetaTx.vue
+++ b/src/components/TransactionTypeTableGAMetaTx.vue
@@ -46,48 +46,25 @@
   </table>
 </template>
 
-<script>
-import { mapActions, mapState } from 'pinia'
+<script setup>
 import { decode } from '@aeternity/aepp-sdk'
 import { formatAePrice, formatAettosToAe, formatNullable } from '@/utils/format'
 import AppLink from '@/components/AppLink'
-import { useTransactionDetailsStore } from '@/stores/transactionDetails'
 
-export default {
-  name: 'TransactionPanelGaMetaTx',
-  components: {
-    AppLink,
+const props = defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  computed: {
-    ...mapState(useTransactionDetailsStore, ['contractId']),
-    innerTransactionDetails() {
-      return this.transactionData.tx.tx
-    },
-    payload() {
-      return formatNullable(decode(this.innerTransactionDetails.payload).toString())
-    },
-  },
-  watch: {
-    transactionData: {
-      immediate: true,
-      handler() {
-        this.fetchContractIdByAccountId(this.transactionData.ga_id)
-      },
-    },
-  },
-  methods: {
-    ...mapActions(useTransactionDetailsStore, ['fetchContractIdByAccountId']),
-    formatNullable,
-    formatAePrice,
-    formatAettosToAe,
-  },
-}
+})
+
+const innerTransactionDetails = computed(() =>
+  props.transactionData.tx.tx,
+)
+
+const payload = computed(() =>
+  formatNullable(decode(innerTransactionDetails.value.payload).toString()),
+)
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableNameClaimTx.vue
+++ b/src/components/TransactionTypeTableNameClaimTx.vue
@@ -35,26 +35,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatAePrice, formatAettosToAe } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableNameClaimTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableNamePreclaimTx.vue
+++ b/src/components/TransactionTypeTableNamePreclaimTx.vue
@@ -15,21 +15,15 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 
-export default {
-  name: 'TransactionTypeTableNamePreclaimTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableNameRevokeTx.vue
+++ b/src/components/TransactionTypeTableNameRevokeTx.vue
@@ -30,25 +30,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableNameRevokeTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatNullable,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableNameTransferTx.vue
+++ b/src/components/TransactionTypeTableNameTransferTx.vue
@@ -40,25 +40,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableNameTransferTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatNullable,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableNameUpdateTx.vue
+++ b/src/components/TransactionTypeTableNameUpdateTx.vue
@@ -38,25 +38,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableNameUpdateTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatNullable,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableOracleExtendTx.vue
+++ b/src/components/TransactionTypeTableOracleExtendTx.vue
@@ -25,16 +25,13 @@
   </table>
 </template>
 
-<script>
-export default {
-  name: 'TransactionTypeTableOracleExtendTx',
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
+<script setup>
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableOracleQueryTx.vue
+++ b/src/components/TransactionTypeTableOracleQueryTx.vue
@@ -69,27 +69,16 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import AppLink from '@/components/AppLink'
 import { formatAePrice, formatAettosToAe, formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableOracleQueryTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatNullable,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableOracleRegisterTx.vue
+++ b/src/components/TransactionTypeTableOracleRegisterTx.vue
@@ -51,23 +51,15 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import { formatAePrice, formatAettosToAe, formatNullable } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableOracleRegisterTx',
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatNullable,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTableOracleRespondTx.vue
+++ b/src/components/TransactionTypeTableOracleRespondTx.vue
@@ -41,23 +41,15 @@
   </table>
 </template>
 
-<script>
-import { formatAePrice, formatAettosToAe, formatDecodeByteArray } from '@/utils/format'
+<script setup>
+import { formatDecodeByteArray } from '@/utils/format'
 
-export default {
-  name: 'TransactionTypeTableOracleRespondTx',
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatDecodeByteArray,
-  },
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/TransactionTypeTablePayingForTx.vue
+++ b/src/components/TransactionTypeTablePayingForTx.vue
@@ -4,26 +4,22 @@
     :transaction-data="innerTransactionDetails"/>
 </template>
 
-<script>
+<script setup>
 import { defineAsyncComponent } from 'vue'
 
-export default {
-  name: 'TransactionTypeTablePayingForTx',
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
+const props = defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  computed: {
-    transactionTypeTableComponent() {
-      return defineAsyncComponent(() =>
-        import(`@/components/TransactionTypeTable${this.innerTransactionDetails.type}.vue`),
-      )
-    },
-    innerTransactionDetails() {
-      return this.transactionData.tx.tx
-    },
-  },
-}
+})
+
+const innerTransactionDetails = computed(() =>
+  props.transactionData.tx.tx,
+)
+const transactionTypeTableComponent = computed(() =>
+  defineAsyncComponent(() =>
+    import(`@/components/TransactionTypeTable${innerTransactionDetails.value.type}.vue`),
+  ),
+)
 </script>

--- a/src/components/TransactionTypeTableSpendTx.vue
+++ b/src/components/TransactionTypeTableSpendTx.vue
@@ -58,29 +58,17 @@
   </table>
 </template>
 
-<script>
+<script setup>
 import { decode } from '@aeternity/aepp-sdk'
 import { formatAePrice, formatAettosToAe, formatEllipseHash } from '@/utils/format'
 import AppLink from '@/components/AppLink'
 
-export default {
-  name: 'TransactionTypeTableSpendTx',
-  components: {
-    AppLink,
+defineProps({
+  transactionData: {
+    required: true,
+    type: Object,
   },
-  props: {
-    transactionData: {
-      required: true,
-      type: Object,
-    },
-  },
-  methods: {
-    formatAePrice,
-    formatAettosToAe,
-    formatEllipseHash,
-    decode,
-  },
-}
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Closes #117 

Implements Composition API in transaction details components

## Demo
No visual changes

![image](https://github.com/aeternity/aescan/assets/46789227/c5e48c9c-8163-4e48-a7fa-30039efb17e3)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does not require a change to the documentation.
