### PR TITLE
fix: release porting ci

### DIFF
--- a/.github/workflows/release-post.yml
+++ b/.github/workflows/release-post.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Create release branch
       if: steps.merge.outcome != 'success'
       run: |
-        git checkout -b port/${{ env.GITHUB_SHA }}
-        git push origin port/${{ env.GITHUB_SHA }}
+        git checkout -b port/${{ github.sha }}
+        git push origin port/${{ github.sha }}
     - name: create pull request
       if: steps.merge.outcome != 'success'
       uses: repo-sync/pull-request@v2


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Resolves #250 

The CI workflow that is responsible for creating a port pull request in case of conflicts was configured incorrectly and causing failure. Now it's fixed. After merging I will try to trigger it manually.

## Demo
Tested on a forked repo
![image](https://github.com/aeternity/aescan/assets/46789227/8ed66220-a8de-4afe-8266-7198fb2002c2)
![image](https://github.com/aeternity/aescan/assets/46789227/935e08df-437a-445d-ba44-be54dad694c7)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does not require a change to the documentation.
