### PR TITLE
feat: Improve hint icon alignment across the application

### DIFF
--- a/src/components/HintIcon.vue
+++ b/src/components/HintIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <app-icon
     name="question"
-    :size="19"
+    :size="16"
     class="hint-icon"/>
 </template>
 <script setup>
@@ -10,6 +10,7 @@ import AppIcon from '@/components/AppIcon'
 
 <style scoped>
 .hint-icon {
+  margin-bottom: 2px;
   color: var(--color-midnight-25);
   cursor: help;
 }

--- a/src/components/HintIcon.vue
+++ b/src/components/HintIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <app-icon
     name="question"
-    :size="16"
+    :size="17"
     class="hint-icon"/>
 </template>
 <script setup>

--- a/src/components/HintTooltip.vue
+++ b/src/components/HintTooltip.vue
@@ -1,6 +1,6 @@
 <template>
   <app-tooltip
-    :skidding="120"
+    :skidding="60"
     has-fixed-width>
     <span class="hint-tooltip__icon">
       <hint-icon/>
@@ -18,7 +18,7 @@ import AppTooltip from '@/components/AppTooltip'
 
 <style scoped>
 .hint-tooltip__icon {
-  height: 25px;
+  line-height: 0;
   display: inline-block;
   vertical-align: middle;
 }

--- a/src/components/StatsTile.vue
+++ b/src/components/StatsTile.vue
@@ -63,7 +63,6 @@ defineProps({
 
   &__tooltip {
     margin-left: var(--space-0);
-    height: 21px;
   }
 
   &__slot {


### PR DESCRIPTION
## Description
resolves #84 

## Demo


https://github.com/aeternity/aescan/assets/15363559/81db6d2c-d2ac-452e-85d5-03788d39e335


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] unify icon usage
- [x] decrease size of icon
