### PR TITLE
fix: switching names type tabs interacting with browser history

### DIFF
--- a/src/components/AppTabs.vue
+++ b/src/components/AppTabs.vue
@@ -22,20 +22,20 @@ import { useVModel } from '@vueuse/core'
 const props = defineProps({
   modelValue: {
     type: Number,
-    default: 0,
+    default: null,
   },
 })
 
-const emit = defineEmits(['update:model-value'])
+const emit = defineEmits(['update:modelValue'])
 
-const activeTabIndex = props.modelValue ? useVModel(props, 'modelValue', emit) : ref(0)
+const activeTabIndex = props.modelValue !== null ? useVModel(props, 'modelValue', emit) : ref(0)
 const tabs = ref([])
 
 provide('registerTab', tab => tabs.value.push(tab))
 
 watch(
   () => props.modelValue,
-  newTabIndex => selectTab(newTabIndex),
+  () => selectTab(activeTabIndex.value),
   { immediate: true },
 )
 

--- a/src/components/AppTabs.vue
+++ b/src/components/AppTabs.vue
@@ -26,12 +26,12 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['update:modelValue'])
+provide('registerTab', tab => tabs.value.push(tab))
 
-const activeTabIndex = props.modelValue !== null ? useVModel(props, 'modelValue', emit) : ref(0)
+const emit = defineEmits(['update:modelValue'])
 const tabs = ref([])
 
-provide('registerTab', tab => tabs.value.push(tab))
+const activeTabIndex = props.modelValue === null ? ref(0) : useVModel(props, 'modelValue', emit)
 
 watch(
   () => props.modelValue,
@@ -40,14 +40,13 @@ watch(
 )
 
 onMounted(() => {
-  tabs.value[activeTabIndex.value].isActive = true
+  selectTab(activeTabIndex.value)
 })
 
-function selectTab(index) {
-  activeTabIndex.value = index
-
+function selectTab(tabIndex) {
+  activeTabIndex.value = tabIndex
   tabs.value.forEach((tab, index) => {
-    tab.isActive = index === activeTabIndex.value
+    tab.isActive = index === tabIndex
   })
 }
 </script>

--- a/src/pages/names/index.vue
+++ b/src/pages/names/index.vue
@@ -41,15 +41,13 @@ const route = useRoute()
 
 const activeTabIndex = computed({
   get() {
-    const { type } = route.query
+    const { type: activeTabName } = route.query
 
-    if (type === undefined) {
+    if (activeTabName === undefined) {
       return 0
     }
 
-    const index = TAB_KEYS.indexOf(type)
-
-    return index >= 0 ? index : 0
+    return TAB_KEYS.indexOf(activeTabName)
   },
   set(index) {
     const newRoute = {
@@ -59,6 +57,7 @@ const activeTabIndex = computed({
     }
 
     if (activeTabIndex.value === index) {
+      // if navigating back
       return replace(newRoute)
     }
 

--- a/src/pages/names/index.vue
+++ b/src/pages/names/index.vue
@@ -57,11 +57,11 @@ const activeTabIndex = computed({
         type: TAB_KEYS[index],
       },
     }
-    
+
     if (activeTabIndex.value === index) {
-       return replace(newRoute)
+      return replace(newRoute)
     }
-    
+
     return push(newRoute)
   },
 })

--- a/src/pages/names/index.vue
+++ b/src/pages/names/index.vue
@@ -36,7 +36,7 @@ import { isDesktop } from '@/utils/screen'
 const TAB_KEYS = ['active', 'in-auction', 'expired']
 
 const { fetchNamesDetails } = useNamesStore()
-const { push } = useRouter()
+const { push, replace } = useRouter()
 const route = useRoute()
 
 const activeTabIndex = computed({
@@ -52,11 +52,17 @@ const activeTabIndex = computed({
     return index >= 0 ? index : 0
   },
   set(index) {
-    push({
+    const newRoute = {
       query: {
         type: TAB_KEYS[index],
       },
-    })
+    }
+    
+    if (activeTabIndex.value === index) {
+       return replace(newRoute)
+    }
+    
+    return push(newRoute)
   },
 })
 


### PR DESCRIPTION
## Description
Resolves #278 

Fixes regression introduced when rewriting this area to composition API. It also improves the interaction with name history so that the `/names` page stays in the browser history only with the included query parameter (no duplicate).

## Demo
https://github.com/aeternity/aescan/assets/46789227/3fd4aab0-42fb-4225-9756-7a7a7db388ce


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does not require a change to the documentation.