### PR TITLE
fix: DataFailedState component does not work with pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,3 @@ website, Github repositories and blog for more information.
 - [æternity middleware](https://github.com/aeternity/ae_mdw)
 - [æternity node](https://github.com/aeternity/aeternity)
 - [æternity node API](https://api-docs.aeternity.io)
-

--- a/src/components/OracleEventsPanel.vue
+++ b/src/components/OracleEventsPanel.vue
@@ -1,6 +1,8 @@
 <template>
   <app-panel class="oracle-events-panel">
     <paginated-content
+      v-if="oracleEvents"
+      v-model:page-index="pageIndex"
       :entities="oracleEvents"
       pagination-style="history"
       @prev-clicked="loadPrevEvents"
@@ -13,6 +15,7 @@
         :oracle-events="oracleEvents"
         class="oracle-events-panel__table-condensed"/>
     </paginated-content>
+    <data-failed-state v-else/>
   </app-panel>
 </template>
 
@@ -21,11 +24,14 @@ import { storeToRefs } from 'pinia'
 import { useOracleDetailsStore } from '@/stores/oracleDetails'
 import OracleEventsTable from '@/components/OracleEventsTable'
 import OracleEventsTableCondensed from '@/components/OracleEventsTableCondensed'
+import DataFailedState from '@/components/DataFailedState'
 
 const oracleDetailsStore = useOracleDetailsStore()
 const { oracleEvents } = storeToRefs(oracleDetailsStore)
 const { fetchOracleEvents } = oracleDetailsStore
 const route = useRoute()
+
+const pageIndex = ref(1)
 
 function loadPrevEvents() {
   fetchOracleEvents(oracleEvents.value.prev)


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Resolves #345 

This change reimplements data-failed-state in oracle events panel. The issue described in the original task was caused by recreating the paginated-content component every time there is data fetching which was resetting the page index back to 1. 

## Demo


https://github.com/aeternity/aescan/assets/46789227/615530d1-5607-403f-986a-89f1de1e611f


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does not require a change to the documentation.
