### PR TITLE
fix: Oracle response of OracleRespondTx transactions is not displayed correctly

### DIFF
--- a/src/components/TransactionCellOracleRespondTx.vue
+++ b/src/components/TransactionCellOracleRespondTx.vue
@@ -1,5 +1,8 @@
 <template>
-  <value-hash-ellipsed :hash="transactionData.oracle_id"/>
+  <value-hash-ellipsed
+    :hash="transactionData.oracle_id"
+    :link-to="`/oracles/${transactionData.oracle_id}`"/>
+
   <transaction-arrow-right-icon/>
 
   <value-hash-ellipsed :hash="transactionData.query_id"/>

--- a/src/components/TransactionCellOracleRespondTx.vue
+++ b/src/components/TransactionCellOracleRespondTx.vue
@@ -7,7 +7,9 @@
 
   <value-hash-ellipsed :hash="transactionData.query_id"/>
 
-  <app-chip size="sm">
+  <app-chip
+    v-if="oracleResponse"
+    size="sm">
     {{ oracleResponse }}
   </app-chip>
 </template>
@@ -24,7 +26,8 @@ const props = defineProps({
     type: Object,
   },
 })
-const oracleResponse = computed(() =>
-  formatDecodeByteArray(props.transactionData.response).slice(0, 8),
-)
+const oracleResponse = computed(() => {
+  const decodedResponse = formatDecodeByteArray(props.transactionData.response)
+  return decodedResponse.length > 8 ? decodedResponse.slice(0, 8) : decodedResponse
+})
 </script>

--- a/src/components/TransactionCellOracleRespondTx.vue
+++ b/src/components/TransactionCellOracleRespondTx.vue
@@ -27,7 +27,8 @@ const props = defineProps({
   },
 })
 const oracleResponse = computed(() => {
-  const decodedResponse = formatDecodeByteArray(props.transactionData.response)
+  const { response } = props.transactionData
+  const decodedResponse = response instanceof Array ? formatDecodeByteArray(response) : response.toString()
   return decodedResponse.length > 8 ? decodedResponse.slice(0, 8) : decodedResponse
 })
 </script>

--- a/src/components/TransactionCellOracleRespondTx.vue
+++ b/src/components/TransactionCellOracleRespondTx.vue
@@ -1,8 +1,5 @@
 <template>
-  <value-hash-ellipsed
-    :hash="transactionData.oracle_id"
-    :link-to="`/oracles/${transactionData.oracle_id}`"/>
-
+  <value-hash-ellipsed :hash="transactionData.oracle_id"/>
   <transaction-arrow-right-icon/>
 
   <value-hash-ellipsed :hash="transactionData.query_id"/>
@@ -16,7 +13,7 @@
 import AppChip from '@/components/AppChip'
 import TransactionArrowRightIcon from '@/components/TransactionArrowRightIcon'
 import ValueHashEllipsed from '@/components/ValueHashEllipsed'
-import { formatDecodeByteArray, formatEllipseHash } from '@/utils/format'
+import { formatDecodeByteArray } from '@/utils/format'
 
 const props = defineProps({
   transactionData: {
@@ -25,6 +22,6 @@ const props = defineProps({
   },
 })
 const oracleResponse = computed(() =>
-  formatEllipseHash(formatDecodeByteArray(props.transactionData.response)),
+  formatDecodeByteArray(props.transactionData.response).slice(0, 8),
 )
 </script>


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
This pr has been forgotten to merge in previous MVP private repo, so just moving it here

## Demo
Before 
![image](https://github.com/aeternity/aescan/assets/15363559/e7fd185e-02b5-425e-a4fe-ae1a4c9aaed1)

After
![image](https://github.com/aeternity/aescan/assets/15363559/34f17869-baf0-431b-b49b-3aba28c7531c)


## Checklist:
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] [truncate Oracle respond data in diffrent way
