### PR TITLE
feat: make pagination button text clickable

### DIFF
--- a/src/components/AppPagination.vue
+++ b/src/components/AppPagination.vue
@@ -4,14 +4,14 @@
       :class="[
         'pagination__container',
         {'pagination__container--disabled': isPrevDisabled},
-      ]">
+      ]"
+      @click="!isPrevDisabled && $emit('prev-clicked')">
       <button
         :class="[
           'pagination__button',
           'pagination__button--prev',
           {'pagination__button--disabled': isPrevDisabled}
-        ]"
-        @click="$emit('prev-clicked')">
+        ]">
         <app-icon
           :size="22"
           name="caret-left"/>
@@ -24,7 +24,8 @@
       :class="[
         'pagination__container',
         {'pagination__container--disabled': isNextDisabled},
-      ]">
+      ]"
+      @click="!isNextDisabled && $emit('next-clicked')">
       <div class="pagination__label">
         {{ nextLabel }}
       </div>
@@ -33,8 +34,7 @@
           'pagination__button',
           'pagination__button--next',
           {'pagination__button--disabled': isNextDisabled}
-        ]"
-        @click="$emit('next-clicked')">
+        ]">
         <app-icon
           :size="22"
           name="caret-right"/>
@@ -76,9 +76,11 @@ defineEmits(['prev-clicked', 'next-clicked'])
     display: flex;
     align-items: center;
     color: var(--color-midnight);
+    cursor: pointer;
 
     &--disabled {
       color: var(--color-midnight-35);
+      cursor: not-allowed;
     }
   }
 


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Resolves #148 
the text next to the pagination button is also clickable

## Demo
It works both for clicking and navigating using tabs (for accessibility reasons)
https://github.com/aeternity/aescan/assets/46789227/fd34c364-dcf8-425c-8536-5051d5bbc138




## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does not require a change to the documentation.
