### PR TITLE
fix: token prices and meaningful number formatting

### DIFF
--- a/src/components/AccountDetailsPanel.vue
+++ b/src/components/AccountDetailsPanel.vue
@@ -131,7 +131,7 @@ const accountNodeUrl = computed(() =>
 )
 const sanitizedPrice = computed(() =>
   price.value
-    ? `$${formatNullable(formatNumber(props.accountDetails.balance * price.value, 0, 2))}`
+    ? `$${formatNullable(formatNumber(props.accountDetails.balance * price.value, 2, 2))}`
     : '---',
 )
 </script>

--- a/src/components/AccountTokensTable.vue
+++ b/src/components/AccountTokensTable.vue
@@ -52,10 +52,10 @@
             :hash="token.contractId "/>
         </td>
         <td>
-          {{ token.amount }}
+          {{ formatNumber(token.amount) }}
         </td>
         <td>
-          {{ token.value !== null ? `$${formatNumber(token.value)}` : 'N/A' }}
+          {{ token.value !== null ? `$${formatNumber(token.value,null,null, 7)}` : 'N/A' }}
         </td>
       </tr>
     </tbody>

--- a/src/components/AccountTokensTableCondensed.vue
+++ b/src/components/AccountTokensTableCondensed.vue
@@ -58,7 +58,7 @@
             </app-tooltip>
           </th>
           <td class="account-tokens-table-condensed__data">
-            {{ token.amount }}
+            {{ formatNumber(token.amount) }}
           </td>
         </tr>
         <tr class="account-tokens-table-condensed__row">
@@ -71,7 +71,7 @@
             </app-tooltip>
           </th>
           <td class="account-tokens-table-condensed__data">
-            {{ token.value !== null ? `$${formatNumber(token.value)}` : 'N/A' }}
+            {{ token.value !== null ? `$${formatNumber(token.value, null, null, 7)}` : 'N/A' }}
           </td>
         </tr>
       </tbody>

--- a/src/components/TokenDetailsPanel.vue
+++ b/src/components/TokenDetailsPanel.vue
@@ -176,7 +176,7 @@ const tokenDexUrl = computed(() =>
 
 const fiatPrice = computed(() =>
   props.tokenDetails.price && price.value
-    ? `$${formatNumber(price.value * props.tokenDetails.price)}`
+    ? `$${formatNumber(price.value * props.tokenDetails.price, null, null, 7)}`
     : '---',
 )
 

--- a/src/components/TokenDetailsPanel.vue
+++ b/src/components/TokenDetailsPanel.vue
@@ -33,7 +33,7 @@
             </hint-tooltip>
           </th>
           <td class="token-details-panel__data">
-            {{ formatAePrice(tokenPrice) }} ({{ fiatPrice }})
+            {{ formatAePrice(tokenDetails.price) }} ({{ fiatPrice }})
           </td>
         </tr>
         <tr
@@ -176,19 +176,13 @@ const tokenDexUrl = computed(() =>
 
 const fiatPrice = computed(() =>
   props.tokenDetails.price && price.value
-    ? `$${price.value / props.tokenDetails.price}`
+    ? `$${formatNumber(price.value * props.tokenDetails.price)}`
     : '---',
 )
 
 const marketCap = computed(() =>
   props.tokenDetails.marketCap && price.value
     ? `$${formatNullable(formatNumber(props.tokenDetails.marketCap * price.value, 0, 2))}`
-    : '---',
-)
-
-const tokenPrice = computed(() =>
-  props.tokenDetails.price
-    ? 1 / props.tokenDetails.price
     : '---',
 )
 </script>

--- a/src/stores/accountDetails.js
+++ b/src/stores/accountDetails.js
@@ -3,17 +3,17 @@ import { useRuntimeConfig } from 'nuxt/app'
 import useAxios from '@/composables/useAxios'
 import { useMarketStatsStore } from '@/stores/marketStats'
 import { adaptAccountNames, adaptTransactions, adaptAccountTokens } from '@/utils/adapters'
-import { formatAettosToAe, formatTokenPairRouteAsRatio } from '@/utils/format'
+import { formatAettosToAe } from '@/utils/format'
+import { useDexStore } from '@/stores/dex'
 
 export const useAccountStore = defineStore('account', () => {
   const {
     MIDDLEWARE_URL,
     NODE_URL,
-    DEX_BACKEND_URL,
-    AE_TOKEN_ID,
   } = useRuntimeConfig().public
   const { price: aeFiatPrice } = storeToRefs(useMarketStatsStore())
   const axios = useAxios()
+  const { fetchPrice } = useDexStore()
 
   const rawAccountDetails = ref(null)
   const accountTransactionsCount = ref(null)
@@ -118,26 +118,12 @@ export const useAccountStore = defineStore('account', () => {
     tokenPrices.value = {}
     await Promise.all(
       rawAccountTokens.value.data.map(async token => {
-        const price = await fetchTokenPrice(token.contractId)
+        const price = await fetchPrice(token.contractId, token.decimals)
         if (price) {
           tokenPrices.value[token.contractId] = price
         }
       }),
     )
-  }
-
-  async function fetchTokenPrice(tokenId) {
-    if (tokenId === AE_TOKEN_ID) {
-      return 1
-    }
-
-    const { data } = await axios.get(`${DEX_BACKEND_URL}/pairs/swap-routes/${tokenId}/${AE_TOKEN_ID}`)
-
-    if (data.length === 0) {
-      return null
-    }
-
-    return formatTokenPairRouteAsRatio(data[0])
   }
 
   async function fetchAccountNamesCount(accountId) {

--- a/src/stores/dex.js
+++ b/src/stores/dex.js
@@ -1,0 +1,57 @@
+import { defineStore } from 'pinia'
+import { useRuntimeConfig } from 'nuxt/app'
+import { BigNumber } from 'bignumber.js'
+import useAxios from '@/composables/useAxios'
+import { MAXIMUM_FRACTION_DIGITS } from '@/utils/constants'
+
+export const useDexStore = defineStore('dex', () => {
+  const { AE_TOKEN_ID, DEX_BACKEND_URL } = useRuntimeConfig().public
+  const axios = useAxios()
+
+  async function fetchPrice(tokenId, tokenDecimals = MAXIMUM_FRACTION_DIGITS) {
+    if (tokenId === AE_TOKEN_ID) {
+      return 1
+    }
+
+    const { data } = await axios.get(`${DEX_BACKEND_URL}/pairs/swap-routes/${tokenId}/${AE_TOKEN_ID}`)
+
+    if (data.length === 0) {
+      return false
+    }
+
+    const ratio = reduceTokenPairRatioWithDecimals(
+      convertTokenPairRouteAsRatio(data[0]),
+      {
+        decimalsA: MAXIMUM_FRACTION_DIGITS,
+        decimalsB: tokenDecimals,
+      },
+    )
+
+    return data[0][0].token0 === AE_TOKEN_ID
+      ? (new BigNumber(1)).dividedBy(ratio).toNumber()
+      : ratio.toNumber()
+  }
+
+  function convertTokenPairRouteAsRatio(route) {
+    return route
+      .map(step => [
+        step.liquidityInfo.reserve0,
+        step.liquidityInfo.reserve1,
+      ])
+      .reduce(
+        (ratio, [reserveA, reserveB]) => ratio.multipliedBy(BigNumber(reserveB).div(reserveA)),
+        new BigNumber(1),
+      )
+  }
+
+  function reduceTokenPairRatioWithDecimals(
+    ratio,
+    { decimalsA, decimalsB },
+  ) {
+    return ratio.shiftedBy(decimalsA - decimalsB)
+  }
+
+  return {
+    fetchPrice,
+  }
+})

--- a/src/stores/tokenDetails.js
+++ b/src/stores/tokenDetails.js
@@ -2,14 +2,15 @@ import { defineStore, storeToRefs } from 'pinia'
 import { useRuntimeConfig } from 'nuxt/app'
 import useAxios from '@/composables/useAxios'
 import { adaptTokenDetails, adaptTokenEvents } from '@/utils/adapters'
-import { formatTokenPairRouteAsRatio } from '@/utils/format'
 import { TOKEN_SUPPLY_ACI } from '@/utils/constants'
 import { useAesdk } from '@/stores/aesdk'
+import { useDexStore } from '@/stores/dex'
 
 export const useTokenDetailsStore = defineStore('tokenDetails', () => {
-  const { AE_TOKEN_ID, DEX_BACKEND_URL, MIDDLEWARE_URL } = useRuntimeConfig().public
+  const { MIDDLEWARE_URL } = useRuntimeConfig().public
   const axios = useAxios()
   const { aeSdk } = storeToRefs(useAesdk())
+  const { fetchPrice } = useDexStore()
 
   const tokenId = ref(null)
   const price = ref(null)
@@ -23,7 +24,8 @@ export const useTokenDetailsStore = defineStore('tokenDetails', () => {
   const tokenDetails = computed(() => rawToken.value
     ? adaptTokenDetails(
       rawToken.value,
-      rawTotalSupply.value, price.value,
+      rawTotalSupply.value,
+      price.value,
     )
     : null,
   )
@@ -47,13 +49,19 @@ export const useTokenDetailsStore = defineStore('tokenDetails', () => {
   function fetchTokenDetails(id) {
     tokenId.value = id
 
+    const tokenPromise = fetchToken()
+
     return Promise.all([
-      fetchToken(),
+      tokenPromise,
       Promise.allSettled([
         fetchTotalSupply(),
-        fetchPrice(),
+        tokenPromise.then(() => fetchTokenPrice()),
       ]),
     ])
+  }
+
+  async function fetchTokenPrice() {
+    price.value = await fetchPrice(tokenId.value, rawToken.value.decimals)
   }
 
   async function fetchToken() {
@@ -68,22 +76,6 @@ export const useTokenDetailsStore = defineStore('tokenDetails', () => {
     })
     const contractCallResult = await contractInstance.total_supply()
     rawTotalSupply.value = contractCallResult?.decodedResult
-  }
-
-  async function fetchPrice() {
-    if (tokenId.value === AE_TOKEN_ID) {
-      price.value = 1
-      return
-    }
-
-    const { data } = await axios.get(`${DEX_BACKEND_URL}/pairs/swap-routes/${tokenId.value}/${AE_TOKEN_ID}`)
-
-    if (data.length === 0) {
-      price.value = false
-      return
-    }
-
-    price.value = formatTokenPairRouteAsRatio(data[0])
   }
 
   async function fetchTokenEvents({ queryParameters, limit, contractId } = {}) {

--- a/src/utils/adapters.js
+++ b/src/utils/adapters.js
@@ -149,14 +149,16 @@ export function adaptAccountNames(names) {
 export function adaptAccountTokens(tokens, tokenPrices, aeFiatPrice) {
   const formattedData = tokens.data.map(token => {
     const amount = token.amount / (10 ** token.decimals)
-    const tokenAePrice = tokenPrices[token.contractId] ? 1 / tokenPrices[token.contractId] : null
+    const tokenAePrice = tokenPrices[token.contractId] || null
 
     return {
       tokenSymbol: token.tokenSymbol,
       tokenName: token.tokenName,
       contractId: token.contractId,
       amount,
-      value: tokenAePrice !== null ? amount * tokenAePrice * aeFiatPrice : null,
+      value: tokenAePrice !== null
+        ? (new BigNumber(amount)).multipliedBy(tokenAePrice).multipliedBy(aeFiatPrice).toNumber()
+        : null,
     }
   })
   return {
@@ -369,11 +371,11 @@ export function adaptTokenDetails(token, totalSupply = null, price = null) {
   }
 
   if (token && totalSupply) {
-    tokenDetails.totalSupply = Number(totalSupply / BigInt(10 ** token.decimals))
+    tokenDetails.totalSupply = (new BigNumber(totalSupply)).dividedBy(10 ** token.decimals).toNumber()
   }
 
   if (tokenDetails.totalSupply && price) {
-    tokenDetails.marketCap = tokenDetails.totalSupply * price
+    tokenDetails.marketCap = (new BigNumber(tokenDetails.totalSupply)).multipliedBy(price).toNumber()
   }
 
   return tokenDetails

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -42,7 +42,7 @@ export const DATETIME_UNITS = [
   'seconds',
 ]
 export const NUMBER_FRACTION_THRESHOLD = 100000
-export const MAXIMUM_FRACTION_DIGITS = 20
+export const MAXIMUM_FRACTION_DIGITS = 18
 export const APP_TITLE_SHORT = 'æScan'
 export const APP_TITLE = 'æScan - æternity Blockchain Explorer'
 export const APP_DESCRIPTION = 'æScan is a blockchain explorer, analytics platform, and decentralized Smart Contract navigation platform based on æternity.'

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -9,13 +9,24 @@ export function formatEllipseHash(hash) {
   return `${prefix}...${suffix}`
 }
 
-export function formatNumber(number, minimumFractionDigits = 0, maximumSignificantDigits = 4) {
+export function formatNumber(
+  number,
+  minimumFractionDigits = 0,
+  maximumFractionDigits = 5,
+  maximumSignificantDigits = null) {
   if (isNaN(number) || number === null) {
     return number
   }
+
+  if (maximumSignificantDigits !== null) {
+    return Intl.NumberFormat('en-US', {
+      maximumSignificantDigits,
+    }).format(number)
+  }
+
   return Intl.NumberFormat('en-US', {
     minimumFractionDigits: number >= NUMBER_FRACTION_THRESHOLD ? 0 : minimumFractionDigits,
-    maximumSignificantDigits,
+    maximumFractionDigits: number >= NUMBER_FRACTION_THRESHOLD ? 0 : maximumFractionDigits,
   }).format(number)
 }
 
@@ -40,7 +51,7 @@ export function formatAePrice(price, maxDigits = 8) {
   decimals = decimals?.replace(/0+$/, '')
 
   if (!decimals) {
-    return integers === '0' && decimals !== '' ? `~${integers} AE` : `${formatNumber(integers)} AE`
+    return integers === '0' ? `~${integers} AE` : `${formatNumber(integers)} AE`
   }
 
   return `${formatNumber(truncatedPrice, decimals.length, maxDigits)} AE`

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -9,13 +9,13 @@ export function formatEllipseHash(hash) {
   return `${prefix}...${suffix}`
 }
 
-export function formatNumber(number, minimumFractionDigits = 0, maximumFractionDigits = 5) {
+export function formatNumber(number, minimumFractionDigits = 0, maximumSignificantDigits = 4) {
   if (isNaN(number) || number === null) {
     return number
   }
   return Intl.NumberFormat('en-US', {
     minimumFractionDigits: number >= NUMBER_FRACTION_THRESHOLD ? 0 : minimumFractionDigits,
-    maximumFractionDigits: number >= NUMBER_FRACTION_THRESHOLD ? 0 : maximumFractionDigits,
+    maximumSignificantDigits,
   }).format(number)
 }
 
@@ -52,18 +52,6 @@ export function formatAettosToAe(aettosAmount) {
   }
 
   return toAe(aettosAmount)
-}
-
-export function formatTokenPairRouteAsRatio(route) {
-  return route
-    .map(step => [
-      step.liquidityInfo.reserve0,
-      step.liquidityInfo.reserve1,
-    ])
-    .reduce(
-      (ratio, [reserveA, reserveB]) => ratio.multipliedBy(BigNumber(reserveB).div(reserveA)),
-      BigNumber(1),
-    )
 }
 
 export function formatBlockDiffAsDatetime(expirationHeight, currentBlockHeight) {


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Resolves #481 

Fixes unreliable token prices and marketcaps  in token details page and account details -> tokens

## Demo
Examples:
account: ak_aeksJqKvh1HD4rSACRjSUGgVe4nEywq6C9VK6VYXwUMezePyH
tokens: ct_KeTvHnhU85vuuQMMZocaiYkPL9tkoavDRT3Jsy47LK2YqLHYb, ct_BwJcRRa7jTAvkpzc2D16tJzHMGCJurtJMUBtyyfGi2QjPuMVv
![image](https://github.com/aeternity/aescan/assets/46789227/a768866b-4220-4718-9c3f-5a6c1b76bbe4)
![image](https://github.com/aeternity/aescan/assets/46789227/62222425-6841-46d3-9a9f-afd294e8e342)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does not require a change to the documentation.
