### PR TITLE
fix: microblocks tx counter at keyblock condensed

### DIFF
--- a/src/components/KeyblockMicroblocksTableCondensed.vue
+++ b/src/components/KeyblockMicroblocksTableCondensed.vue
@@ -44,7 +44,7 @@
           </th>
           <td class="keyblock-microblocks-table-condensed__data">
             <div>
-              {{ microblock.microblockTransactionsCount }}
+              {{ microblock.transactionsCount }}
             </div>
           </td>
         </tr>


### PR DESCRIPTION
The tx counter for the microbloks in a keyblock was not showing on the condensed keyblock view due to wrong property given.

<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
<!--- Describe your changes in detail -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
<!--- If it doesn't resolve any open issues, tell us why is this change required? What problem does it solve? -->

## Demo
<!--- Show us a video or screenshots that present the changes. Before/after comparison is very welcome -->

| Before | After |
| ------ | ----- |
|  ![Screenshot from 2023-11-07 08-56-24](https://github.com/aeternity/aescan/assets/13139371/e8bd184a-a102-42ed-b205-9056ad565dd8)  |  ![Screenshot from 2023-11-07 08-56-32](https://github.com/aeternity/aescan/assets/13139371/df8d6118-42a3-4c43-a866-2dc14ee07e2c)  |

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] My change does not require a change to the documentation.
