### PR TITLE
feat: add contract id to generalized account

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,5 @@
     "last 2 versions",
     "not dead",
     "not ie 11"
-  ],
-  "packageManager": "yarn@4.0.1"
+  ]
 }

--- a/src/components/AccountDetailsPanel.vue
+++ b/src/components/AccountDetailsPanel.vue
@@ -4,7 +4,9 @@
       DETAILS
     </template>
     <template #header>
-      <app-chip v-if="accountDetails.isGeneralized">
+      <app-chip
+        v-if="accountDetails.isGeneralized"
+        size="sm">
         Generalized
       </app-chip>
 
@@ -70,7 +72,24 @@
             {{ formatNumber(accountDetails.namesCount) }}
           </td>
         </tr>
-        <tr class="account-details-panel__row">
+        <tr
+          v-if="accountDetails.isGeneralized"
+          class="account-details-panel__row">
+          <th class="account-details-panel__table-header">
+            Contract Id
+            <hint-tooltip>
+              {{ accountHints.contractId }}
+            </hint-tooltip>
+          </th>
+          <td class="account-details-panel__data">
+            <app-link :to="`/contracts/${accountDetails.contractId}`">
+              {{ accountDetails.contractId }}
+            </app-link>
+          </td>
+        </tr>
+        <tr
+          v-else
+          class="account-details-panel__row">
           <th class="account-details-panel__table-header">
             Nonce
             <hint-tooltip>
@@ -116,6 +135,7 @@ import AppLink from '@/components/AppLink'
 import { formatAePrice, formatEllipseHash, formatNullable, formatNumber } from '@/utils/format'
 import { useMarketStatsStore } from '@/stores/marketStats'
 import HintTooltip from '@/components/HintTooltip'
+import AppChip from '~/components/AppChip'
 
 const { price } = storeToRefs(useMarketStatsStore())
 const { NODE_URL } = useRuntimeConfig().public

--- a/src/utils/hints/accountHints.js
+++ b/src/utils/hints/accountHints.js
@@ -5,6 +5,7 @@ export const accountHints = {
   transactions: 'Amount of transactions where the account was involved.',
   aensNames: 'Amount of names owned by the account.',
   nonce: 'The nonce that was used to execute the last transaction for the account. The nonce is used to prevent replay attacks and keep transactions in order. If a transaction with a way higher nonce is broadcasted, it won\'t be executed until all transactions with lower nonces are executed.',
+  contractId: 'The contract that is attached to the account to create generalized account and takes over its authorization logic.',
   apiLinks: 'Node API link of the account.',
   hash: 'Transaction hash where the account was involved.',
   time: 'Keyblock height and exact date and time when the transaction was executed by inclusion into a microblock.',


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
resolves #471 

## Demo
Generalized Account view (Nonce hidden)
![image](https://github.com/aeternity/aescan/assets/15363559/fae97c9d-b2ff-46fa-976b-f361860a0a3b)

Basic account (Nonce but no contract ID)
![image](https://github.com/aeternity/aescan/assets/15363559/2e472b7e-382f-45a5-8426-0eacfc9cfc13)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] display link to contract attached to generalized account 
