### PR TITLE
fix: remove unused attempt for account names counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,5 @@
     "last 2 versions",
     "not dead",
     "not ie 11"
-  ],
-  "packageManager": "yarn@4.0.1"
+  ]
 }

--- a/src/stores/accountDetails.js
+++ b/src/stores/accountDetails.js
@@ -17,7 +17,6 @@ export const useAccountStore = defineStore('account', () => {
 
   const rawAccountDetails = ref(null)
   const totalAccountTransactionsCount = ref(null)
-  const accountNamesCount = ref(null)
   const selectedKeyblock = ref(null)
   const selectedMicroblock = ref(null)
   const selectedKeyblockMicroblocks = ref(null)
@@ -34,7 +33,6 @@ export const useAccountStore = defineStore('account', () => {
         ...rawAccountDetails.value,
         balance: formatAettosToAe(rawAccountDetails.value.balance),
         totalTransactionsCount: totalAccountTransactionsCount.value,
-        namesCount: accountNamesCount.value,
         isGeneralized: rawAccountDetails.value.kind === 'generalized',
       }
       : null,
@@ -70,7 +68,6 @@ export const useAccountStore = defineStore('account', () => {
         fetchAccountTransactions({ accountId, limit }),
         fetchTotalAccountTransactionsCount(accountId),
         fetchAccountNames({ accountId, limit }),
-        fetchAccountNamesCount(accountId),
         fetchAccountActivities({ accountId, limit }),
       ]),
     ])
@@ -126,11 +123,6 @@ export const useAccountStore = defineStore('account', () => {
     )
   }
 
-  async function fetchAccountNamesCount(accountId) {
-    const { data } = await axios.get(`${MIDDLEWARE_URL}/v2/names?owned_by=${accountId}&state=active`)
-    accountNamesCount.value = data.data.length
-  }
-
   async function fetchAccountActivities({ accountId, limit, queryParameters } = {}) {
     rawAccountActivities.value = null
     const defaultParameters = `/v2/accounts/${accountId}/activities?limit=${limit ?? 10}`
@@ -166,7 +158,6 @@ export const useAccountStore = defineStore('account', () => {
   return {
     rawAccountDetails,
     totalAccountTransactionsCount,
-    accountNamesCount,
     selectedKeyblock,
     selectedMicroblock,
     selectedKeyblockMicroblocks,


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Initially I grabbed the issue https://github.com/aeternity/aescan/issues/553
Found out that 
1) Such an endpoint does not exist (requested here https://github.com/aeternity/ae_mdw/issues/1629)
2) There was a wrong attempt to get names count, that was not even implemented (dead code) SO at least I removed the dead code

## Demo
Without any visual change. Should work the same

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] remove attempt to get names count manually
