### PR TITLE
feat: Top accounts

### DIFF
--- a/src/components/MicroblockTransactionsPanel.vue
+++ b/src/components/MicroblockTransactionsPanel.vue
@@ -24,7 +24,7 @@ import { storeToRefs } from 'pinia'
 import { ref } from 'vue'
 import { useRouter } from '#app'
 import { useMicroblockDetailsStore } from '@/stores/microblockDetails'
-import { TX_TYPES_OPTIONS } from '~/utils/constants'
+import { TX_TYPES_OPTIONS } from '@/utils/constants'
 
 const { push } = useRouter()
 const microblockDetailsStore = useMicroblockDetailsStore()

--- a/src/components/TopAccountsPanel.vue
+++ b/src/components/TopAccountsPanel.vue
@@ -1,33 +1,22 @@
 <template>
   <app-panel>
-    <table>
-      <tr>
-        <th>Rank</th>
-        <th>Account</th>
-        <th>% Of Circulating</th>
-      </tr>
-      <tr
-        v-for="account in topAccounts"
-        :key="account.account">
-        <td>{{ account.rank }}.</td>
-        <td>
-          <app-link
-            :to="`/accounts/${account.account}`">
-            {{ account.account }}
-          </app-link>
-        </td>
-        <td>{{ account.percentage }} %</td>
-      </tr>
-    </table>
+    <top-accounts-table
+      :top-accounts="topAccounts"
+      class="u-hidden-mobile"/>
+    <top-accounts-table-condensed
+      :top-accounts="topAccounts"
+      class="u-hidden-desktop"/>
   </app-panel>
 </template>
 
 <script setup>
 import { useTopAccountsStore } from '~/stores/topAccounts'
 import { useBlockchainStatsStore } from '~/stores/blockchainStats'
+import TopAccountsTable from '~/components/TopAccountsTable'
+import TopAccountsTableCondensed from '~/components/TopAccountsTableCondensed'
 
 const topAccountsStore = useTopAccountsStore()
-const { topAccounts, distribution } = storeToRefs(topAccountsStore)
+const { topAccounts } = storeToRefs(topAccountsStore)
 const { fetchTopAccounts } = useTopAccountsStore()
 const { fetchTotalStats } = useBlockchainStatsStore()
 

--- a/src/components/TopAccountsPanel.vue
+++ b/src/components/TopAccountsPanel.vue
@@ -4,19 +4,19 @@
       <tr>
         <th>Rank</th>
         <th>Account</th>
-        <th>Balance</th>
+        <th>% Of Circulating</th>
       </tr>
       <tr
-        v-for="(account, index) in topAccounts"
-        :key="index">
-        <td>{{ index + 1 }}</td>
+        v-for="account in topAccounts"
+        :key="account.account">
+        <td>{{ account.rank }}.</td>
         <td>
           <app-link
             :to="`/accounts/${account.account}`">
             {{ account.account }}
           </app-link>
         </td>
-        <td>{{ account.balance }}</td>
+        <td>{{ account.percentage }} %</td>
       </tr>
     </table>
   </app-panel>
@@ -24,13 +24,16 @@
 
 <script setup>
 import { useTopAccountsStore } from '~/stores/topAccounts'
+import { useBlockchainStatsStore } from '~/stores/blockchainStats'
 
 const topAccountsStore = useTopAccountsStore()
-const { topAccounts } = storeToRefs(topAccountsStore)
+const { topAccounts, distribution } = storeToRefs(topAccountsStore)
 const { fetchTopAccounts } = useTopAccountsStore()
+const { fetchTotalStats } = useBlockchainStatsStore()
 
 await useAsyncData(async() => {
   await fetchTopAccounts()
+  await fetchTotalStats()
   return true
 })
 </script>

--- a/src/components/TopAccountsPanel.vue
+++ b/src/components/TopAccountsPanel.vue
@@ -10,10 +10,10 @@
 </template>
 
 <script setup>
-import { useTopAccountsStore } from '~/stores/topAccounts'
-import { useBlockchainStatsStore } from '~/stores/blockchainStats'
-import TopAccountsTable from '~/components/TopAccountsTable'
-import TopAccountsTableCondensed from '~/components/TopAccountsTableCondensed'
+import { useTopAccountsStore } from '@/stores/topAccounts'
+import { useBlockchainStatsStore } from '@/stores/blockchainStats'
+import TopAccountsTable from '@/components/TopAccountsTable'
+import TopAccountsTableCondensed from '@/components/TopAccountsTableCondensed'
 
 const topAccountsStore = useTopAccountsStore()
 const { topAccounts } = storeToRefs(topAccountsStore)

--- a/src/components/TopAccountsPanel.vue
+++ b/src/components/TopAccountsPanel.vue
@@ -1,0 +1,36 @@
+<template>
+  <app-panel>
+    <table>
+      <tr>
+        <th>Rank</th>
+        <th>Account</th>
+        <th>Balance</th>
+      </tr>
+      <tr
+        v-for="(account, index) in topAccounts"
+        :key="index">
+        <td>{{ index + 1 }}</td>
+        <td>
+          <app-link
+            :to="`/accounts/${account.account}`">
+            {{ account.account }}
+          </app-link>
+        </td>
+        <td>{{ account.balance }}</td>
+      </tr>
+    </table>
+  </app-panel>
+</template>
+
+<script setup>
+import { useTopAccountsStore } from '~/stores/topAccounts'
+
+const topAccountsStore = useTopAccountsStore()
+const { topAccounts } = storeToRefs(topAccountsStore)
+const { fetchTopAccounts } = useTopAccountsStore()
+
+await useAsyncData(async() => {
+  await fetchTopAccounts()
+  return true
+})
+</script>

--- a/src/components/TopAccountsTable.vue
+++ b/src/components/TopAccountsTable.vue
@@ -1,0 +1,52 @@
+<template>
+  <table class="top-accounts-table">
+    <tr>
+      <th>
+        Rank
+        <hint-tooltip>
+          {{ stateChannelsHints.stateChannelId }}
+        </hint-tooltip>
+      </th>
+      <th>
+        Account
+        <hint-tooltip>
+          {{ stateChannelsHints.stateChannelId }}
+        </hint-tooltip>
+      </th>
+      <th>
+        % Of Circulating
+        <hint-tooltip>
+          {{ stateChannelsHints.stateChannelId }}
+        </hint-tooltip>
+      </th>
+    </tr>
+    <tr
+      v-for="account in topAccounts"
+      :key="account.account">
+      <td>{{ account.rank }}.</td>
+      <td>
+        <app-link
+          :to="`/accounts/${account.account}`">
+          {{ account.account }}
+        </app-link>
+      </td>
+      <td>{{ account.percentage }} %</td>
+    </tr>
+  </table>
+</template>
+<script setup>
+import { stateChannelsHints } from '~/utils/hints/stateChannelsHints'
+
+defineProps({
+  topAccounts: {
+    type: Array,
+    required: true,
+  },
+})
+</script>
+
+<style scoped>
+.top-accounts-table {
+  margin-bottom: var(--space-4);
+}
+</style>

--- a/src/components/TopAccountsTable.vue
+++ b/src/components/TopAccountsTable.vue
@@ -4,19 +4,19 @@
       <th>
         Rank
         <hint-tooltip>
-          {{ stateChannelsHints.stateChannelId }}
+          {{ topAccountsHints.rank }}
         </hint-tooltip>
       </th>
       <th>
         Account
         <hint-tooltip>
-          {{ stateChannelsHints.stateChannelId }}
+          {{ topAccountsHints.account }}
         </hint-tooltip>
       </th>
       <th>
         % Of Circulating
         <hint-tooltip>
-          {{ stateChannelsHints.stateChannelId }}
+          {{ topAccountsHints.percentage }}
         </hint-tooltip>
       </th>
     </tr>
@@ -35,7 +35,7 @@
   </table>
 </template>
 <script setup>
-import { stateChannelsHints } from '@/utils/hints/stateChannelsHints'
+import { topAccountsHints } from '@/utils/hints/topAccountsHints'
 
 defineProps({
   topAccounts: {

--- a/src/components/TopAccountsTable.vue
+++ b/src/components/TopAccountsTable.vue
@@ -35,7 +35,7 @@
   </table>
 </template>
 <script setup>
-import { stateChannelsHints } from '~/utils/hints/stateChannelsHints'
+import { stateChannelsHints } from '@/utils/hints/stateChannelsHints'
 
 defineProps({
   topAccounts: {

--- a/src/components/TopAccountsTable.vue
+++ b/src/components/TopAccountsTable.vue
@@ -14,6 +14,12 @@
         </hint-tooltip>
       </th>
       <th>
+        Balance
+        <hint-tooltip>
+          {{ topAccountsHints.balance }}
+        </hint-tooltip>
+      </th>
+      <th>
         % Of Circulating
         <hint-tooltip>
           {{ topAccountsHints.percentage }}
@@ -24,12 +30,14 @@
       v-for="account in topAccounts"
       :key="account.account">
       <td>{{ account.rank }}.</td>
+
       <td>
         <app-link
           :to="`/accounts/${account.account}`">
           {{ account.account }}
         </app-link>
       </td>
+      <td>{{ account.balance }}</td>
       <td>{{ account.percentage }} %</td>
     </tr>
   </table>

--- a/src/components/TopAccountsTableCondensed.vue
+++ b/src/components/TopAccountsTableCondensed.vue
@@ -1,5 +1,4 @@
 <template>
-  <!--  todo hints-->
   <div>
     <table
       v-for="account in topAccounts"
@@ -11,7 +10,7 @@
             <app-tooltip>
               Rank
               <template #tooltip>
-                {{ stateChannelsHints.stateChannelId }}
+                {{ topAccountsHints.rank }}
               </template>
             </app-tooltip>
           </th>
@@ -24,7 +23,7 @@
             <app-tooltip>
               Account
               <template #tooltip>
-                {{ stateChannelsHints.status }}
+                {{ topAccountsHints.account }}
               </template>
             </app-tooltip>
           </th>
@@ -40,7 +39,7 @@
             <app-tooltip>
               % Of Circulating
               <template #tooltip>
-                {{ stateChannelsHints.participants }}
+                {{ topAccountsHints.percentage }}
               </template>
             </app-tooltip>
           </th>
@@ -53,6 +52,8 @@
   </div>
 </template>
 <script setup>
+
+import { topAccountsHints } from '../utils/hints/topAccountsHints'
 
 defineProps({
   topAccounts: {

--- a/src/components/TopAccountsTableCondensed.vue
+++ b/src/components/TopAccountsTableCondensed.vue
@@ -1,6 +1,5 @@
 <template>
   <!--  todo hints-->
-  <!--  todo imports-->
   <div>
     <table
       v-for="account in topAccounts"

--- a/src/components/TopAccountsTableCondensed.vue
+++ b/src/components/TopAccountsTableCondensed.vue
@@ -1,0 +1,85 @@
+<template>
+  <!--  todo hints-->
+  <!--  todo imports-->
+  <div>
+    <table
+      v-for="account in topAccounts"
+      :key="account.account"
+      class="top-accounts-table-condensed__table">
+      <tbody>
+        <tr class="top-accounts-table-condensed__row">
+          <th class="top-accounts-table-condensed__header">
+            <app-tooltip>
+              Rank
+              <template #tooltip>
+                {{ stateChannelsHints.stateChannelId }}
+              </template>
+            </app-tooltip>
+          </th>
+          <td class="top-accounts-table-condensed__data">
+            {{ account.rank }}.
+          </td>
+        </tr>
+        <tr class="top-accounts-table-condensed__row">
+          <th class="top-accounts-table-condensed__header">
+            <app-tooltip>
+              Account
+              <template #tooltip>
+                {{ stateChannelsHints.status }}
+              </template>
+            </app-tooltip>
+          </th>
+          <td class="top-accounts-table-condensed__data">
+            <app-link
+              :to="`/accounts/${account.account}`">
+              {{ account.account }}
+            </app-link>
+          </td>
+        </tr>
+        <tr class="top-accounts-table-condensed__row">
+          <th class="top-accounts-table-condensed__header">
+            <app-tooltip>
+              % Of Circulating
+              <template #tooltip>
+                {{ stateChannelsHints.participants }}
+              </template>
+            </app-tooltip>
+          </th>
+          <td class="top-accounts-table-condensed__data">
+            {{ account.percentage }} %
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+<script setup>
+
+defineProps({
+  topAccounts: {
+    type: Array,
+    required: true,
+  },
+})
+</script>
+
+<style scoped>
+.top-accounts-table-condensed {
+  &__table {
+    padding: 0 var(--space-1) var(--space-7);
+    margin-bottom: var(--space-5);
+  }
+
+  &__header {
+    border-bottom: 1px solid var(--color-midnight-25);
+  }
+
+  &__row:last-of-type &__header {
+    border-bottom: 0;
+  }
+
+  &__data {
+    text-align: right;
+  }
+}
+</style>

--- a/src/components/TopAccountsTableCondensed.vue
+++ b/src/components/TopAccountsTableCondensed.vue
@@ -53,7 +53,7 @@
 </template>
 <script setup>
 
-import { topAccountsHints } from '../utils/hints/topAccountsHints'
+import { topAccountsHints } from '@/utils/hints/topAccountsHints'
 
 defineProps({
   topAccounts: {

--- a/src/components/TopAccountsTableCondensed.vue
+++ b/src/components/TopAccountsTableCondensed.vue
@@ -37,6 +37,19 @@
         <tr class="top-accounts-table-condensed__row">
           <th class="top-accounts-table-condensed__header">
             <app-tooltip>
+              Balance
+              <template #tooltip>
+                {{ topAccountsHints.balance }}
+              </template>
+            </app-tooltip>
+          </th>
+          <td class="top-accounts-table-condensed__data">
+            {{ account.balance }}
+          </td>
+        </tr>
+        <tr class="top-accounts-table-condensed__row">
+          <th class="top-accounts-table-condensed__header">
+            <app-tooltip>
               % Of Circulating
               <template #tooltip>
                 {{ topAccountsHints.percentage }}

--- a/src/pages/top-accounts/index.vue
+++ b/src/pages/top-accounts/index.vue
@@ -1,0 +1,22 @@
+<template>
+  <Head>
+    <Title>Top Accounts</Title>
+  </Head>
+
+  <page-header>
+    Top Accounts
+    <!--todo hints-->
+    <template #tooltip>
+      {{ tokensHints.token }}
+    </template>
+  </page-header>
+  <top-accounts-panel v-if="!isLoading"/>
+  <loader-panel v-else/>
+</template>
+
+<script setup>
+import PageHeader from '@/components/PageHeader'
+import { tokensHints } from '@/utils/hints/tokensHints'
+
+const { isLoading } = useLoading()
+</script>

--- a/src/pages/top-accounts/index.vue
+++ b/src/pages/top-accounts/index.vue
@@ -5,9 +5,8 @@
 
   <page-header>
     Top Accounts
-    <!--todo hints-->
     <template #tooltip>
-      {{ tokensHints.token }}
+      {{ topAccountsHints.topAccounts }}
     </template>
   </page-header>
   <top-accounts-panel v-if="!isLoading"/>
@@ -16,7 +15,7 @@
 
 <script setup>
 import PageHeader from '@/components/PageHeader'
-import { tokensHints } from '@/utils/hints/tokensHints'
+import { topAccountsHints } from '~/utils/hints/topAccountsHints'
 
 const { isLoading } = useLoading()
 </script>

--- a/src/stores/topAccounts.js
+++ b/src/stores/topAccounts.js
@@ -1,0 +1,16 @@
+export const useTopAccountsStore = defineStore('topAccounts', () => {
+  const axios = useAxios()
+  const topAccounts = ref(null)
+  const { MIDDLEWARE_URL } = useRuntimeConfig().public
+
+  async function fetchTopAccounts() {
+    topAccounts.value = null
+    const { data } = await axios.get(`${MIDDLEWARE_URL}/v2/wealth`)
+    topAccounts.value = data
+  }
+
+  return {
+    topAccounts,
+    fetchTopAccounts,
+  }
+})

--- a/src/stores/topAccounts.js
+++ b/src/stores/topAccounts.js
@@ -1,4 +1,4 @@
-import { useBlockchainStatsStore } from '~/stores/blockchainStats'
+import { useBlockchainStatsStore } from '@/stores/blockchainStats'
 
 export const useTopAccountsStore = defineStore('topAccounts', () => {
   const axios = useAxios()

--- a/src/stores/topAccounts.js
+++ b/src/stores/topAccounts.js
@@ -4,14 +4,13 @@ export const useTopAccountsStore = defineStore('topAccounts', () => {
   const axios = useAxios()
   const rawTopAccounts = ref(null)
   const { MIDDLEWARE_URL } = useRuntimeConfig().public
-
   const blockchainStatsStore = useBlockchainStatsStore()
 
-  async function fetchTopAccounts() {
-    rawTopAccounts.value = null
-    const { data } = await axios.get(`${MIDDLEWARE_URL}/v2/wealth`)
-    rawTopAccounts.value = data
-  }
+  const topAccounts = computed(() =>
+    rawTopAccounts.value && distribution.value
+      ? adaptTopAccounts(rawTopAccounts.value, distribution.value)
+      : null,
+  )
 
   const distribution = computed(() =>
     blockchainStatsStore.totalTokenSupply && blockchainStatsStore.burnedCount
@@ -19,20 +18,14 @@ export const useTopAccountsStore = defineStore('topAccounts', () => {
       : null,
   )
 
-  const topAccounts = computed(() => {
-    // console.log('1 blockchainStatsStore', blockchainStatsStore)
-    // console.log('1 blockchainStatsStore.totalTokenSupply', blockchainStatsStore.totalTokenSupply.value)
-    // console.log('1 blockchainStatsStore.burnedCount', blockchainStatsStore.burnedCount.value)
-
-    return rawTopAccounts.value && distribution.value
-      ? adaptTopAccounts(rawTopAccounts.value, distribution.value)
-      : null
-  })
+  async function fetchTopAccounts() {
+    rawTopAccounts.value = null
+    const { data } = await axios.get(`${MIDDLEWARE_URL}/v2/wealth`)
+    rawTopAccounts.value = data
+  }
 
   return {
     topAccounts,
     fetchTopAccounts,
-    distribution,
   }
-  // todo remove dis
 })

--- a/src/stores/topAccounts.js
+++ b/src/stores/topAccounts.js
@@ -1,16 +1,38 @@
+import { useBlockchainStatsStore } from '~/stores/blockchainStats'
+
 export const useTopAccountsStore = defineStore('topAccounts', () => {
   const axios = useAxios()
-  const topAccounts = ref(null)
+  const rawTopAccounts = ref(null)
   const { MIDDLEWARE_URL } = useRuntimeConfig().public
 
+  const blockchainStatsStore = useBlockchainStatsStore()
+
   async function fetchTopAccounts() {
-    topAccounts.value = null
+    rawTopAccounts.value = null
     const { data } = await axios.get(`${MIDDLEWARE_URL}/v2/wealth`)
-    topAccounts.value = data
+    rawTopAccounts.value = data
   }
+
+  const distribution = computed(() =>
+    blockchainStatsStore.totalTokenSupply && blockchainStatsStore.burnedCount
+      ? Number(blockchainStatsStore.totalTokenSupply) + Number(blockchainStatsStore.burnedCount)
+      : null,
+  )
+
+  const topAccounts = computed(() => {
+    // console.log('1 blockchainStatsStore', blockchainStatsStore)
+    // console.log('1 blockchainStatsStore.totalTokenSupply', blockchainStatsStore.totalTokenSupply.value)
+    // console.log('1 blockchainStatsStore.burnedCount', blockchainStatsStore.burnedCount.value)
+
+    return rawTopAccounts.value && distribution.value
+      ? adaptTopAccounts(rawTopAccounts.value, distribution.value)
+      : null
+  })
 
   return {
     topAccounts,
     fetchTopAccounts,
+    distribution,
   }
+  // todo remove dis
 })

--- a/src/utils/adapters.js
+++ b/src/utils/adapters.js
@@ -603,3 +603,13 @@ export function adaptNft(nft) {
     templateLimit: formatTemplateLimit(nft.extensions, nft.limits?.templateLimit),
   }
 }
+
+export function adaptTopAccounts(topAccounts, distribution) {
+  return topAccounts.map((account, index) => {
+    return {
+      rank: index + 1,
+      account: account.account,
+      percentage: (formatAettosToAe(account.balance) * 100 / distribution).toFixed(2),
+    }
+  })
+}

--- a/src/utils/adapters.js
+++ b/src/utils/adapters.js
@@ -609,6 +609,7 @@ export function adaptTopAccounts(topAccounts, distribution) {
     return {
       rank: index + 1,
       account: account.account,
+      balance: formatAePrice(formatAettosToAe(account.balance)),
       percentage: (formatAettosToAe(account.balance) * 100 / distribution).toFixed(2),
     }
   })

--- a/src/utils/hints/topAccountsHints.js
+++ b/src/utils/hints/topAccountsHints.js
@@ -1,0 +1,6 @@
+export const topAccountsHints = {
+  topAccounts: 'The top accounts are the accounts with the highest balance of AE coins.',
+  rank: 'Rank of the account in the top accounts list.',
+  account: 'Account address.',
+  percentage: 'Percentage of the total supply of AE coins that the account holds.',
+}

--- a/src/utils/hints/topAccountsHints.js
+++ b/src/utils/hints/topAccountsHints.js
@@ -1,6 +1,7 @@
 export const topAccountsHints = {
   topAccounts: 'The top accounts are the accounts with the highest balance of AE coins.',
   rank: 'Rank of the account in the top accounts list.',
+  balance: 'Amount of AE tokens held by the account',
   account: 'Account address.',
   percentage: 'Percentage of the total supply of AE coins that the account holds.',
 }


### PR DESCRIPTION


## Description
resolves #616 

- The endpoint responds with top 200 accounts. Cannot be limited to 100. I think we can proceed with that
- There is no entrypoint for the feature yet. So the only way to check the feature is to go to `/top-accounts` URL. The entripoint is a part of new menu here https://github.com/aeternity/aescan/pull/627

## Demo
![image](https://github.com/aeternity/aescan/assets/15363559/45e80446-a80d-4746-92a0-68aedfebbae9)



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [X] add top accounts page
