### PR TITLE
fix:  If user look at the activity of the selected account, then in the third step the view will break

### DIFF
--- a/src/components/AccountActivityCell.vue
+++ b/src/components/AccountActivityCell.vue
@@ -95,6 +95,8 @@ const activityDescription = computed(() => {
     return 'Internal transfer'
   case 'Aex9TransferEvent':
     return 'Transferred to'
+  case 'Aex141TransferEvent':
+    return 'Transferred to'
   case 'InternalContractCallEvent':
     return 'Internal call'
   default:

--- a/src/components/AccountActivityDataCell.vue
+++ b/src/components/AccountActivityDataCell.vue
@@ -42,7 +42,8 @@ const isActivityCell = computed(() => {
       props.activity.type === 'NamePreclaimTxEvent' ||
       props.activity.type === 'InternalContractCallEvent' ||
       props.activity.type === 'InternalTransferEvent' ||
-      props.activity.type === 'Aex9TransferEvent') {
+      props.activity.type === 'Aex9TransferEvent' ||
+      props.activity.type === 'Aex141TransferEvent') {
     return true
   } else {
     return false

--- a/src/components/AccountActivityDataCellAex141TransferEvent.vue
+++ b/src/components/AccountActivityDataCellAex141TransferEvent.vue
@@ -1,0 +1,24 @@
+<template>
+  <value-hash-ellipsed
+    :hash="activityPayload.contractId"
+    :link-to="`/contracts/${activityPayload.contractId}`"/>
+
+  <app-chip size="sm">
+    {{ activityPayload.tokenName }}
+  </app-chip>
+</template>
+
+<script setup>
+import AppChip from '@/components/AppChip'
+import ValueHashEllipsed from '@/components/ValueHashEllipsed'
+
+const props = defineProps({
+  activity: {
+    type: Object,
+    required: true,
+  },
+})
+
+const activityPayload = computed(() => props.activity.payload)
+
+</script>

--- a/src/components/AccountActivityDataCellAex141TransferEvent.vue
+++ b/src/components/AccountActivityDataCellAex141TransferEvent.vue
@@ -1,7 +1,7 @@
 <template>
   <value-hash-ellipsed
-    :hash="activityPayload.contractId"
-    :link-to="`/contracts/${activityPayload.contractId}`"/>
+    :hash="activityPayload.recipientId"
+    :link-to="`/accounts/${activityPayload.recipientId}`"/>
 
   <app-chip size="sm">
     {{ activityPayload.tokenName }}

--- a/src/components/AccountActivityTypeCell.vue
+++ b/src/components/AccountActivityTypeCell.vue
@@ -75,6 +75,8 @@ const activityType = computed(() => {
 
   case 'Aex9TransferEvent':
     return 'AEX-9'
+  case 'Aex141TransferEvent':
+    return 'AEX-141'
   case 'InternalContractCallEvent':
     if (
       SH_DEX_CONTRACTS.includes(props.activity.payload.contractId)) {


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
fixes #628
related https://github.com/aeternity/aescan/issues/362

## Demo

https://github.com/aeternity/aescan/assets/15363559/f326a9a7-446f-4e5c-b087-b984d195faa9


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [x] add aex141 transfer event activity component
