### PR TITLE
fix: The full file path is not visible when Contract Files are uploaded

### DIFF
--- a/src/components/ContractFileList.vue
+++ b/src/components/ContractFileList.vue
@@ -5,7 +5,7 @@
       :key="index"
       class="contract-file-list__item">
       <span @click="selectEntryFile(file, index)">
-        {{ file.webkitRelativePath || file.name }}
+        {{ file.webkitRelativePath }}
         <app-chip
           v-if="index === entryFile.index"
           class="contract-file-list__chip"

--- a/src/components/ContractsFileUpload.vue
+++ b/src/components/ContractsFileUpload.vue
@@ -103,7 +103,7 @@ function drop(event) {
 }
 
 function selectEntryFile(file, index) {
-  const name = file.webkitRelativePath || file.name
+  const name = file.webkitRelativePath
   entryFile.value = { index, name }
   emit('update:entry-file', name)
 }
@@ -133,6 +133,10 @@ function getFileEntry(entry, files) {
 function getSingleFile(fileEntry, files) {
   return new Promise(resolve => {
     fileEntry.file(file => {
+      // chrome workaround to manually set webkitRelativePath
+      Object.defineProperty(file, 'webkitRelativePath', {
+        value: fileEntry.fullPath.substring(1),
+      })
       files.push(file)
       selectedFiles.value.push(file)
       resolve(file)


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
fixes #728 

## Demo
<!--- Show us a video or screenshots that present the changes. Before/after comparison is very welcome -->

https://github.com/aeternity/aescan/assets/15363559/bd0db3de-9a40-470d-8fc8-ac3fc5de7327


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  

