### PR TITLE
fix: Show accounts created in genesis block

### DIFF
--- a/src/components/KeyblockDetailsPanel.vue
+++ b/src/components/KeyblockDetailsPanel.vue
@@ -39,6 +39,7 @@
               <pagination-button
                 class="keyblock-details-panel__button--prev"
                 direction="left"
+                :disabled="keyblockDetails.height === 0"
                 @click="$router.push(`/keyblocks/${keyblockDetails.height - 1}`)"/>
 
               {{ keyblockDetails.height }}
@@ -107,7 +108,7 @@
             Beneficiary Reward
           </th>
           <td>
-            {{ formatAePrice(keyblockDetails.blockReward, null) }}
+            {{ formatNullable(formatAePrice(keyblockDetails.blockReward, null)) }}
           </td>
         </tr>
         <tr class="keyblock-details-panel__row">
@@ -118,7 +119,7 @@
             BRI Reward
           </th>
           <td>
-            {{ formatAePrice(keyblockDetails.devReward, null) }}
+            {{ formatNullable(formatAePrice(keyblockDetails.devReward, null)) }}
           </td>
         </tr>
         <tr class="keyblock-details-panel__row">


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
<!--- Describe your changes in detail -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
<!--- If it doesn't resolve any open issues, tell us why is this change required? What problem does it solve? -->

resolves #838 

## Demo
<!--- Show us a video or screenshots that present the changes. Before/after comparison is very welcome -->

BEFORE
![image](https://github.com/aeternity/aescan/assets/15363559/00469ad7-c635-42e1-8878-9752fd7dec33)



AFTER
![image](https://github.com/aeternity/aescan/assets/15363559/24d4140f-9d03-4a89-8509-077c90d93e68)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  

