### PR TITLE
fix: expose port 8080 in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ COPY --chown=node:node --from=build /app/.output ./
 USER node
 
 ENV HOST=0.0.0.0
-ENV PORT=80
+ENV PORT=8080
 ENV NODE_ENV=production
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD [ "node", "/app/server/index.mjs" ]


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Port 8080 has to be exposed, instead of 80, because the process is started by a non-root user which can't expose ports like 80.
<!--- Describe your changes in detail -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
<!--- If it doesn't resolve any open issues, tell us why is this change required? What problem does it solve? -->

## Demo
<!--- Show us a video or screenshots that present the changes. Before/after comparison is very welcome -->

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
