### PR TITLE
feat: add per page selector

### DIFF
--- a/src/components/AccountActivitiesPanel.vue
+++ b/src/components/AccountActivitiesPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="account-activities-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="accountActivities"
       pagination-style="history"
       @prev-clicked="loadPrevActivities"
@@ -14,8 +15,15 @@
 </template>
 
 <script setup>
+const route = useRoute()
 const { fetchAccountActivities } = useAccountStore()
 const { accountActivities, accountDetails } = storeToRefs(useAccountStore())
+
+const pageLimit = usePageLimit('account-activities')
+
+watch(pageLimit, () => {
+  fetchAccountActivities({ accountId: route.params.id, limit: pageLimit.value })
+})
 
 function loadPrevActivities() {
   return fetchAccountActivities({

--- a/src/components/AccountNamesPanel.vue
+++ b/src/components/AccountNamesPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="account-names-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="accountNames"
       @prev-clicked="loadPrevAccountNames"
       @next-clicked="loadNextAccountNames">
@@ -12,8 +13,15 @@
 </template>
 
 <script setup>
+const route = useRoute()
 const { fetchAccountNames } = useAccountStore()
 const { accountNames } = storeToRefs(useAccountStore())
+
+const pageLimit = usePageLimit('account-names')
+
+watch(pageLimit, () => {
+  fetchAccountNames({ accountId: route.params.id, limit: pageLimit.value })
+})
 
 async function loadPrevAccountNames() {
   await fetchAccountNames({ queryParameters: accountNames.value.prev.substring(3) })

--- a/src/components/AccountTokensPanel.vue
+++ b/src/components/AccountTokensPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="account-tokens-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="accountTokens"
       @prev-clicked="loadPrevAccountTokens"
       @next-clicked="loadNextAccountTokens">
@@ -10,8 +11,15 @@
 </template>
 
 <script setup>
+const route = useRoute()
 const { fetchAccountTokens } = useAccountStore()
 const { accountTokens } = storeToRefs(useAccountStore())
+
+const pageLimit = usePageLimit('account-tokens')
+
+watch(pageLimit, () => {
+  fetchAccountTokens({ accountId: route.params.id, limit: pageLimit.value })
+})
 
 async function loadPrevAccountTokens() {
   await fetchAccountTokens({ queryParameters: accountTokens.value.prev.substring(3) })

--- a/src/components/AccountTransactionsPanel.vue
+++ b/src/components/AccountTransactionsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="account-transactions-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       v-model:page-index="pageIndex"
       :entities="accountTransactions"
       pagination-style="history"
@@ -23,11 +24,22 @@ const { accountTransactions } = storeToRefs(useAccountStore())
 
 const selectedTxType = ref({ typeQuery: null, label: 'All types' })
 const pageIndex = ref(1)
+const pageLimit = usePageLimit('account-transactions')
 
 watch(selectedTxType, () => {
   fetchAccountTransactions({
     accountId: route.params.id,
     type: selectedTxType.value.typeQuery,
+    limit: pageLimit.value,
+  })
+  pageIndex.value = 1
+})
+
+watch(pageLimit, () => {
+  fetchAccountTransactions({
+    accountId: route.params.id,
+    type: selectedTxType.value.typeQuery,
+    limit: pageLimit.value,
   })
   pageIndex.value = 1
 })

--- a/src/components/AeCoinMarketsTable.vue
+++ b/src/components/AeCoinMarketsTable.vue
@@ -38,10 +38,10 @@
             AE / USDT
           </td>
           <td class="ae-coin-markets-table__data">
-            $ {{ formatNullable(formatNumber(coinMarkets.gate.price)) }}
+            $ {{ formatNullable(formatNumber(coinMarkets.gate?.price)) }}
           </td>
           <td class="ae-coin-markets-table__data">
-            $ {{ formatNullable(formatNumber(coinMarkets.gate.volume)) }}
+            $ {{ formatNullable(formatNumber(coinMarkets.gate?.volume)) }}
           </td>
         </tr>
         <tr>
@@ -52,10 +52,10 @@
             AE / USDT
           </td>
           <td class="ae-coin-markets-table__data">
-            $ {{ formatNullable(formatNumber(coinMarkets.mexc.price)) }}
+            $ {{ formatNullable(formatNumber(coinMarkets.mexc?.price)) }}
           </td>
           <td class="ae-coin-markets-table__data">
-            $ {{ formatNullable(formatNumber(coinMarkets.mexc.volume)) }}
+            $ {{ formatNullable(formatNumber(coinMarkets.mexc?.volume)) }}
           </td>
         </tr>
         <tr>
@@ -66,10 +66,10 @@
             AE / USDT
           </td>
           <td class="ae-coin-markets-table__data">
-            $ {{ formatNullable(formatNumber(coinMarkets.hotcoin.price)) }}
+            $ {{ formatNullable(formatNumber(coinMarkets.hotcoin?.price)) }}
           </td>
           <td class="ae-coin-markets-table__data">
-            $ {{ formatNullable(formatNumber(coinMarkets.hotcoin.volume)) }}
+            $ {{ formatNullable(formatNumber(coinMarkets.hotcoin?.volume)) }}
           </td>
         </tr>
         <tr>
@@ -80,10 +80,10 @@
             AE / USDT
           </td>
           <td class="ae-coin-markets-table__data">
-            $ {{ formatNullable(formatNumber(coinMarkets.coinw.price)) }}
+            $ {{ formatNullable(formatNumber(coinMarkets.coinw?.price)) }}
           </td>
           <td class="ae-coin-markets-table__data">
-            $ {{ formatNullable(formatNumber(coinMarkets.coinw.volume)) }}
+            $ {{ formatNullable(formatNumber(coinMarkets.coinw?.volume)) }}
           </td>
         </tr>
       </tbody>

--- a/src/components/AeCoinTransactionsPanel.vue
+++ b/src/components/AeCoinTransactionsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="ae-coin-transactions-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="transactions"
       :total-count="transactionsCount"
       @prev-clicked="loadPrevTransactions"
@@ -14,8 +15,14 @@
 const { fetchTransactions, fetchTransactionsCount } = useTransactionsStore()
 const { transactions, transactionsCount } = storeToRefs(useTransactionsStore())
 
+const pageLimit = usePageLimit('ae-coin-transactions')
+
+watch(pageLimit, () => {
+  loadTransactions()
+})
+
 async function loadTransactions() {
-  await fetchTransactions({ type: 'spend', limit: 10 })
+  await fetchTransactions({ type: 'spend', limit: pageLimit.value })
   await fetchTransactionsCount({ type: 'spend' })
 }
 

--- a/src/components/ContractCallTransactionsPanel.vue
+++ b/src/components/ContractCallTransactionsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="contract-call-transactions-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :total-count="contractCallsCount"
       :entities="contractCallTransactions"
       pagination-style="history"
@@ -15,6 +16,12 @@
 const { contractCallTransactions, contractCallsCount } = storeToRefs(useContractDetailsStore())
 const { fetchContractCallTransactions } = useContractDetailsStore()
 
+const pageLimit = usePageLimit('contract-call-transactions')
+
+watch(pageLimit, () => {
+  fetchContractCallTransactions({ limit: pageLimit.value })
+})
+
 function loadPrevTransactions() {
   fetchContractCallTransactions({
     queryParameters: contractCallTransactions.value.prev.substring(3),
@@ -28,6 +35,6 @@ function loadNextTransactions() {
 }
 
 if (import.meta.client) {
-  fetchContractCallTransactions()
+  fetchContractCallTransactions({ limit: pageLimit.value })
 }
 </script>

--- a/src/components/ContractEventsPanel.vue
+++ b/src/components/ContractEventsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="contract-events-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="contractEvents"
       pagination-style="history"
       @prev-clicked="loadPrevEvents"
@@ -17,11 +18,17 @@
 const { fetchContractEvents } = useContractDetailsStore()
 const { contractEvents, contractDetails } = storeToRefs(useContractDetailsStore())
 
+const pageLimit = usePageLimit('contract-events')
+
+watch(pageLimit, () => {
+  fetchContractEvents({ limit: pageLimit.value })
+})
+
 function loadPrevEvents() {
-  fetchContractEvents(contractEvents.value.prev.substring(3))
+  fetchContractEvents({ queryParameters: contractEvents.value.prev.substring(3) })
 }
 
 function loadNextEvents() {
-  fetchContractEvents(contractEvents.value.next.substring(3))
+  fetchContractEvents({ queryParameters: contractEvents.value.next.substring(3) })
 }
 </script>

--- a/src/components/ContractsPanel.vue
+++ b/src/components/ContractsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="contracts-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="contracts"
       :total-count="contractsCount"
       pagination-style="history"
@@ -15,16 +16,22 @@
 const { contracts, contractsCount } = storeToRefs(useContractsStore())
 const { fetchContracts, fetchContractsCount } = useContractsStore()
 
+const pageLimit = usePageLimit('contracts')
+
+watch(pageLimit, () => {
+  loadContracts()
+})
+
 function loadPrevContracts() {
-  fetchContracts(contracts.value.prev)
+  fetchContracts({ queryParameters: contracts.value.prev })
 }
 
 function loadNextContracts() {
-  fetchContracts(contracts.value.next)
+  fetchContracts({ queryParameters: contracts.value.next })
 }
 
 function loadContracts() {
-  fetchContracts('/v3/transactions?type=contract_create&limit=10')
+  fetchContracts({ limit: pageLimit.value })
   fetchContractsCount()
 }
 

--- a/src/components/DexTradesPanel.vue
+++ b/src/components/DexTradesPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="trades"
       pagination-style="history"
       @prev-clicked="loadPrevEvents"
@@ -14,20 +15,26 @@
 const { trades } = storeToRefs(useDexTradesStore())
 const { fetchDexTrades } = useDexTradesStore()
 
+const pageLimit = usePageLimit('dex-trades')
+
+watch(pageLimit, () => {
+  fetchDexTrades({ limit: pageLimit.value })
+})
+
 useAsyncData(async () => {
-  await fetchDexTrades()
+  await fetchDexTrades({ limit: pageLimit.value })
   return true
 })
 
 function loadPrevEvents() {
-  fetchDexTrades(trades.value.prev.substring(3))
+  fetchDexTrades({ queryParameters: trades.value.prev.substring(3) })
 }
 
 function loadNextEvents() {
-  fetchDexTrades(trades.value.next.substring(3))
+  fetchDexTrades({ queryParameters: trades.value.next.substring(3) })
 }
 
 if (import.meta.client) {
-  fetchDexTrades()
+  fetchDexTrades({ limit: pageLimit.value })
 }
 </script>

--- a/src/components/KeyblockMicroblocksPanel.vue
+++ b/src/components/KeyblockMicroblocksPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="keyblock-microblock-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       pagination-style="history"
       :entities="microblocks"
       :total-count="keyblockDetails.microBlocksCount"
@@ -18,9 +19,16 @@ const { keyblockMicroblocks: microblocks, keyblockDetails } = storeToRefs(useKey
 const { fetchKeyblockMicroblocks } = useKeyblockDetailsStore()
 const route = useRoute()
 
+const pageLimit = usePageLimit('keyblock-microblocks')
+
+watch(pageLimit, () => {
+  fetchKeyblockMicroblocks({ id: route.params.id, limit: pageLimit.value })
+})
+
 if (import.meta.client) {
   fetchKeyblockMicroblocks({
     id: route.params.id,
+    limit: pageLimit.value,
   })
 }
 

--- a/src/components/KeyblockTransactionsPanel.vue
+++ b/src/components/KeyblockTransactionsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="keyblock-transactions-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       v-model:page-index="pageIndex"
       :entities="transactions"
       :total-count="transactions?.count"
@@ -28,6 +29,7 @@ const { push } = useRouter()
 
 const selectedTxType = ref(TX_TYPES_OPTIONS[0])
 const pageIndex = ref(1)
+const pageLimit = usePageLimit('keyblock-transactions')
 
 function loadPrevTransactions() {
   fetchKeyblockTransactions({
@@ -52,6 +54,7 @@ async function loadTransactions() {
   await fetchKeyblockTransactions({
     height: keyblockDetails.value?.height,
     type: selectedTxType.value?.typeQuery,
+    limit: pageLimit.value,
   })
   pageIndex.value = 1
 }
@@ -64,6 +67,9 @@ if (import.meta.client) {
     const typeQuery = selectedTxType.value?.typeQuery
     const slug = `${typeQuery ? '?txType=' + typeQuery : ''}`
     push(`/keyblocks/${route.params.id}${slug}`)
+  })
+  watch(pageLimit, () => {
+    loadTransactions()
   })
 
   loadTransactions()

--- a/src/components/KeyblocksPanel.vue
+++ b/src/components/KeyblocksPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="keyblocks"
       :total-count="keyblocksCount"
       pagination-style="history"
@@ -15,15 +16,21 @@
 const { fetchKeyblocks } = useKeyblockStore()
 const { keyblocks, keyblocksCount } = storeToRefs(useKeyblockStore())
 
+const pageLimit = usePageLimit('keyblocks')
+
+watch(pageLimit, () => {
+  fetchKeyblocks({ limit: pageLimit.value })
+})
+
 async function loadPrevKeyblocks() {
-  await fetchKeyblocks(keyblocks.value.prev)
+  await fetchKeyblocks({ queryParameters: keyblocks.value.prev })
 }
 
 async function loadNextKeyblocks() {
-  await fetchKeyblocks(keyblocks.value.next)
+  await fetchKeyblocks({ queryParameters: keyblocks.value.next })
 }
 
 if (import.meta.client) {
-  fetchKeyblocks()
+  fetchKeyblocks({ limit: pageLimit.value })
 }
 </script>

--- a/src/components/MicroblockTransactionsPanel.vue
+++ b/src/components/MicroblockTransactionsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="microblock-transactions-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       v-model:page-index="pageIndex"
       :entities="transactions"
       :total-count="transactions?.count"
@@ -26,6 +27,7 @@ const { push } = useRouter()
 
 const selectedTxType = ref(TX_TYPES_OPTIONS[0])
 const pageIndex = ref(1)
+const pageLimit = usePageLimit('microblock-transactions')
 
 function loadPrevTransactions() {
   fetchMicroblockTransactions({ queryParameters: transactions.value.prev })
@@ -40,7 +42,7 @@ async function loadTransactions() {
   const txTypeOption = TX_TYPES_OPTIONS.find(option => option.typeQuery === txType)
   selectedTxType.value = txTypeOption || TX_TYPES_OPTIONS[0]
   await fetchMicroblockTransactions({
-    limit: 10,
+    limit: pageLimit.value,
     microblockHash: route.params.id,
     type: selectedTxType.value?.typeQuery,
   })
@@ -55,6 +57,9 @@ if (import.meta.client) {
     const typeQuery = selectedTxType.value?.typeQuery
     const slug = `${typeQuery ? '?txType=' + typeQuery : ''}`
     push(`/microblocks/${route.params.id}${slug}`)
+  })
+  watch(pageLimit, () => {
+    loadTransactions()
   })
 
   loadTransactions()

--- a/src/components/MinersPanel.vue
+++ b/src/components/MinersPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="miners-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="miners"
       :total-count="minersCount"
       pagination-style="history"
@@ -17,16 +18,22 @@
 const { miners, minersCount } = storeToRefs(useMiningStore())
 const { fetchMiners } = useMiningStore()
 
+const pageLimit = usePageLimit('miners')
+
+watch(pageLimit, () => {
+  fetchMiners({ limit: pageLimit.value })
+})
+
 function loadPrevMiners() {
-  fetchMiners(miners.value.prev)
+  fetchMiners({ queryParameters: miners.value.prev })
 }
 
 function loadNextMiners() {
-  fetchMiners(miners.value.next)
+  fetchMiners({ queryParameters: miners.value.next })
 }
 
 if (import.meta.client) {
-  await fetchMiners()
+  await fetchMiners({ limit: pageLimit.value })
 }
 </script>
 

--- a/src/components/NameHistoryPanel.vue
+++ b/src/components/NameHistoryPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="name-history-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="nameHistory"
       pagination-style="history"
       @prev-clicked="loadPrevActions"
@@ -14,8 +15,15 @@
 </template>
 
 <script setup>
+const route = useRoute()
 const { fetchNameHistory } = useNameDetailsStore()
 const { nameHistory } = storeToRefs(useNameDetailsStore())
+
+const pageLimit = usePageLimit('name-history')
+
+watch(pageLimit, () => {
+  fetchNameHistory({ nameHash: route.params.id, limit: pageLimit.value })
+})
 
 function loadPrevActions() {
   return fetchNameHistory({ queryParameters: nameHistory.value.prev.substring(3) })

--- a/src/components/NamesActivePanel.vue
+++ b/src/components/NamesActivePanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="names-active-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="activeNames"
       @prev-clicked="loadPrevNames"
       @next-clicked="loadNextNames">
@@ -16,12 +17,18 @@
 const { fetchActiveNames } = useNamesStore()
 const { activeNames } = storeToRefs(useNamesStore())
 
+const pageLimit = usePageLimit('names-active')
+
+watch(pageLimit, () => {
+  fetchActiveNames({ limit: pageLimit.value })
+})
+
 function loadPrevNames() {
-  return fetchActiveNames(activeNames.value.prev)
+  return fetchActiveNames({ queryParameters: activeNames.value.prev })
 }
 
 function loadNextNames() {
-  return fetchActiveNames(activeNames.value.next)
+  return fetchActiveNames({ queryParameters: activeNames.value.next })
 }
 </script>
 

--- a/src/components/NamesExpiredPanel.vue
+++ b/src/components/NamesExpiredPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="names-expired-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="expiredNames"
       @prev-clicked="loadPrevNames"
       @next-clicked="loadNextNames">
@@ -16,12 +17,18 @@
 const { fetchExpiredNames } = useNamesStore()
 const { expiredNames } = storeToRefs(useNamesStore())
 
+const pageLimit = usePageLimit('names-expired')
+
+watch(pageLimit, () => {
+  fetchExpiredNames({ limit: pageLimit.value })
+})
+
 function loadPrevNames() {
-  fetchExpiredNames(expiredNames.value.prev)
+  fetchExpiredNames({ queryParameters: expiredNames.value.prev })
 }
 
 function loadNextNames() {
-  fetchExpiredNames(expiredNames.value.next)
+  fetchExpiredNames({ queryParameters: expiredNames.value.next })
 }
 </script>
 

--- a/src/components/NamesInAuctionPanel.vue
+++ b/src/components/NamesInAuctionPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="names-in-auction-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="inAuctionNames"
       @prev-clicked="loadPrevNames"
       @next-clicked="loadNextNames">
@@ -16,12 +17,18 @@
 const { fetchInAuctionNames } = useNamesStore()
 const { inAuctionNames } = storeToRefs(useNamesStore())
 
+const pageLimit = usePageLimit('names-in-auction')
+
+watch(pageLimit, () => {
+  fetchInAuctionNames({ limit: pageLimit.value })
+})
+
 function loadPrevNames() {
-  fetchInAuctionNames(inAuctionNames.value.prev)
+  fetchInAuctionNames({ queryParameters: inAuctionNames.value.prev })
 }
 
 function loadNextNames() {
-  fetchInAuctionNames(inAuctionNames.value.next)
+  fetchInAuctionNames({ queryParameters: inAuctionNames.value.next })
 }
 </script>
 

--- a/src/components/NftInventoryPanel.vue
+++ b/src/components/NftInventoryPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       pagination-style="history"
       :entities="nftInventory"
       @next-clicked="loadNextNftInventory"
@@ -13,8 +14,15 @@
 </template>
 
 <script setup>
+const route = useRoute()
 const { nftInventory } = storeToRefs(useNftDetailsStore())
 const { fetchNftInventory } = useNftDetailsStore()
+
+const pageLimit = usePageLimit('nft-inventory')
+
+watch(pageLimit, () => {
+  fetchNftInventory({ id: route.params.id, limit: pageLimit.value })
+})
 
 async function loadPrevNftInventory() {
   await fetchNftInventory({ queryParameters: nftInventory.value.prev })

--- a/src/components/NftOwnersPanel.vue
+++ b/src/components/NftOwnersPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="nftOwners"
       @next-clicked="loadNextNftowners"
       @prev-clicked="loadPrevNftowners">
@@ -12,8 +13,15 @@
 </template>
 
 <script setup>
+const route = useRoute()
 const { nftOwners } = storeToRefs(useNftDetailsStore())
 const { fetchNftOwners } = useNftDetailsStore()
+
+const pageLimit = usePageLimit('nft-owners')
+
+watch(pageLimit, () => {
+  fetchNftOwners({ id: route.params.id, limit: pageLimit.value })
+})
 
 async function loadNextNftowners() {
   await fetchNftOwners({ queryParameters: nftOwners.value.next })

--- a/src/components/NftTemplatesOwnersPanel.vue
+++ b/src/components/NftTemplatesOwnersPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="nft-templates-owners-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="nftOwners"
       @next-clicked="loadNextNftowners"
       @prev-clicked="loadPrevNftowners">
@@ -12,8 +13,15 @@
 </template>
 
 <script setup>
+const route = useRoute()
 const { nftOwners } = storeToRefs(useNftDetailsStore())
 const { fetchNftOwners } = useNftDetailsStore()
+
+const pageLimit = usePageLimit('nft-templates-owners')
+
+watch(pageLimit, () => {
+  fetchNftOwners({ id: route.params.id, limit: pageLimit.value })
+})
 
 async function loadNextNftowners() {
   await fetchNftOwners({ queryParameters: nftOwners.value.next })

--- a/src/components/NftTransfersPanel.vue
+++ b/src/components/NftTransfersPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="nftTransfers"
       pagination-style="history"
       @prev-clicked="loadPrevNftTransfers"
@@ -11,8 +12,15 @@
 </template>
 
 <script setup>
+const route = useRoute()
 const { nftTransfers } = storeToRefs(useNftDetailsStore())
 const { fetchNftTransfers } = useNftDetailsStore()
+
+const pageLimit = usePageLimit('nft-transfers')
+
+watch(pageLimit, () => {
+  fetchNftTransfers({ id: route.params.id, limit: pageLimit.value })
+})
 
 async function loadPrevNftTransfers() {
   await fetchNftTransfers({ queryParameters: nftTransfers.value.prev })

--- a/src/components/NftsPanel.vue
+++ b/src/components/NftsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="nfts"
       :total-count="nfts?.count"
       @prev-clicked="loadPrevNfts"
@@ -14,15 +15,21 @@
 const { nfts } = storeToRefs(useNftsStore())
 const { fetchNfts } = useNftsStore()
 
+const pageLimit = usePageLimit('nfts')
+
+watch(pageLimit, () => {
+  fetchNfts({ limit: pageLimit.value })
+})
+
 async function loadPrevNfts() {
-  await fetchNfts(nfts.value.prev)
+  await fetchNfts({ queryParameters: nfts.value.prev })
 }
 
 async function loadNextNfts() {
-  await fetchNfts(nfts.value.next)
+  await fetchNfts({ queryParameters: nfts.value.next })
 }
 
 if (import.meta.client) {
-  fetchNfts()
+  fetchNfts({ limit: pageLimit.value })
 }
 </script>

--- a/src/components/OracleEventsPanel.vue
+++ b/src/components/OracleEventsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="oracle-events-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="oracleEvents"
       pagination-style="history"
       @prev-clicked="loadPrevEvents"
@@ -18,6 +19,12 @@ const { fetchOracleEvents } = useOracleDetailsStore()
 
 const route = useRoute()
 
+const pageLimit = usePageLimit('oracle-events')
+
+watch(pageLimit, () => {
+  fetchOracleEvents({ id: route.params.id, limit: pageLimit.value })
+})
+
 function loadPrevEvents() {
   fetchOracleEvents({ queryParameters: oracleEvents.value.prev })
 }
@@ -27,7 +34,7 @@ function loadNextEvents() {
 }
 
 if (import.meta.client) {
-  fetchOracleEvents({ limit: 10, id: route.params.id })
+  fetchOracleEvents({ id: route.params.id, limit: pageLimit.value })
 }
 </script>
 

--- a/src/components/OraclesPanel.vue
+++ b/src/components/OraclesPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       v-model:page-index="pageIndex"
       :entities="oracles"
       :total-count="oraclesCount"
@@ -22,6 +23,7 @@ const { fetchOracles, fetchOraclesCount } = useOraclesStore()
 const { oracles, oraclesCount } = storeToRefs(useOraclesStore())
 
 const pageIndex = ref(1)
+const pageLimit = usePageLimit('oracles')
 
 function loadPrevOracles() {
   fetchOracles({ queryParameters: oracles.value.prev })
@@ -36,7 +38,7 @@ async function loadOracles() {
   const oracleStateOption = ORACLE_STATES_OPTIONS.find(option => option.stateQuery === state)
   selectedOracleState.value = oracleStateOption || ORACLE_STATES_OPTIONS[0]
   await Promise.all([
-    await fetchOracles({ limit: 10, state: selectedOracleState.value.stateQuery }),
+    await fetchOracles({ limit: pageLimit.value, state: selectedOracleState.value.stateQuery }),
     await fetchOraclesCount(selectedOracleState.value.stateQuery),
   ])
   pageIndex.value = 1
@@ -67,6 +69,9 @@ const selectedOracleState = computed({
 
 if (import.meta.client) {
   watch(() => route.fullPath, () => {
+    loadOracles()
+  })
+  watch(pageLimit, () => {
     loadOracles()
   })
 

--- a/src/components/PaginatedContent.vue
+++ b/src/components/PaginatedContent.vue
@@ -8,12 +8,12 @@
         class="paginated-content__header">
         <div class="paginated-content__counter">
           <span v-if="hasCounter">
-            <template v-if="totalCount > 0">
+            <template v-if="effectiveTotalCount > 0">
               Displaying
               <span class="paginated-content__highlighted">
                 {{ formatNullable(firstVisibleIndex) }}-{{ formatNullable(lastVisibleIndex) }}
                 of
-                {{ formatNullable(totalCount) }}
+                {{ formatNullable(effectiveTotalCount) }}
               </span>
               records
             </template>
@@ -112,13 +112,17 @@ const firstVisibleIndex = computed(
   () => (pageIndex.value - 1) * limitModel.value + 1,
 )
 const lastVisibleIndex = computed(
-  () => firstVisibleIndex.value + props.entities?.data.length - 1,
+  () => firstVisibleIndex.value + (props.entities?.data?.length ?? 0) - 1,
 )
+const effectiveTotalCount = computed(() => {
+  if (props.totalCount === null) return null
+  return Math.max(props.totalCount, lastVisibleIndex.value)
+})
 
 const isPrevDisabled = computed(() => !props.entities.prev || pageIndex.value === 1)
 const isNextDisabled = computed(() => !props.entities.next)
 const hasPagination = computed(() => !!props.entities.data.length && (props.entities.prev || props.entities.next))
-const hasCounter = computed(() => props.totalCount !== null && props.totalCount > 0)
+const hasCounter = computed(() => effectiveTotalCount.value !== null && effectiveTotalCount.value > 0)
 const hasLimitSelector = computed(() => !!props.entities?.data?.length)
 const prevLabel = computed(() => {
   if (props.paginationStyle === 'history') {

--- a/src/components/PaginatedContent.vue
+++ b/src/components/PaginatedContent.vue
@@ -4,7 +4,7 @@
     class="paginated-content">
     <template v-if="entities">
       <header
-        v-if="hasCounter || $slots.header"
+        v-if="hasCounter || hasLimitSelector || $slots.header"
         class="paginated-content__header">
         <div class="paginated-content__counter">
           <span v-if="hasCounter">
@@ -25,6 +25,19 @@
           </span>
         </div>
         <div
+          v-if="hasLimitSelector"
+          class="paginated-content__per-page">
+          <span class="paginated-content__per-page-label">per page:</span>
+          <button
+            v-for="option in PAGINATION_LIMIT_OPTIONS"
+            :key="option"
+            class="paginated-content__per-page-option"
+            :class="{'paginated-content__per-page-option--active': limitModel === option}"
+            @click="setLimit(option)">
+            {{ option }}
+          </button>
+        </div>
+        <div
           v-if="$slots.header"
           class="paginated-content__slot-header">
           <slot name="header"/>
@@ -39,15 +52,18 @@
         v-else
         class="paginated-content__blank-state"/>
 
-      <app-pagination
+      <div
         v-if="hasPagination"
-        class="paginated-content__pagination"
-        :is-prev-disabled="isPrevDisabled"
-        :is-next-disabled="isNextDisabled"
-        :prev-label="prevLabel"
-        :next-label="nextLabel"
-        @prev-clicked="handlePrevClicked"
-        @next-clicked="handleNextClicked"/>
+        class="paginated-content__footer">
+        <app-pagination
+          class="paginated-content__pagination"
+          :is-prev-disabled="isPrevDisabled"
+          :is-next-disabled="isNextDisabled"
+          :prev-label="prevLabel"
+          :next-label="nextLabel"
+          @prev-clicked="handlePrevClicked"
+          @next-clicked="handleNextClicked"/>
+      </div>
     </template>
     <div v-else>
       <loader-indicator class="paginated-content__loader-indicator"/>
@@ -57,7 +73,7 @@
 
 <script setup>
 import { useVModel } from '@vueuse/core'
-import { PAGINATION_LIMIT } from '@/utils/constants'
+import { PAGINATION_LIMIT, PAGINATION_LIMIT_OPTIONS } from '@/utils/constants'
 
 const props = defineProps({
   entities: {
@@ -67,6 +83,10 @@ const props = defineProps({
   pageIndex: {
     type: [Number, null],
     default: null,
+  },
+  limit: {
+    type: Number,
+    default: PAGINATION_LIMIT,
   },
   totalCount: {
     type: [Number, null],
@@ -84,10 +104,12 @@ const emit = defineEmits([
   'prev-clicked',
   'next-clicked',
   'update:pageIndex',
+  'update:limit',
 ])
 const pageIndex = props.pageIndex ? useVModel(props, 'pageIndex', emit) : ref(1)
+const limitModel = useVModel(props, 'limit', emit)
 const firstVisibleIndex = computed(
-  () => (pageIndex.value - 1) * PAGINATION_LIMIT + 1,
+  () => (pageIndex.value - 1) * limitModel.value + 1,
 )
 const lastVisibleIndex = computed(
   () => firstVisibleIndex.value + props.entities?.data.length - 1,
@@ -97,6 +119,7 @@ const isPrevDisabled = computed(() => !props.entities.prev || pageIndex.value ==
 const isNextDisabled = computed(() => !props.entities.next)
 const hasPagination = computed(() => !!props.entities.data.length && (props.entities.prev || props.entities.next))
 const hasCounter = computed(() => props.totalCount !== null && props.totalCount > 0)
+const hasLimitSelector = computed(() => !!props.entities?.data?.length)
 const prevLabel = computed(() => {
   if (props.paginationStyle === 'history') {
     return 'Newer'
@@ -123,6 +146,13 @@ function handleNextClicked() {
   setFixedContainerHeight()
   pageIndex.value++
   emit('next-clicked')
+}
+
+function setLimit(option) {
+  if (limitModel.value !== option) {
+    limitModel.value = option
+    pageIndex.value = 1
+  }
 }
 
 watch(
@@ -214,7 +244,50 @@ onBeforeUnmount(() => {
   }
 
   &__pagination {
+    flex: 1;
+  }
+
+  &__footer {
+    display: flex;
     width: 100%;
+    margin-top: var(--space-2);
+  }
+
+  &__per-page {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    flex-wrap: wrap;
+  }
+
+  &__per-page-label {
+    font-family: var(--font-monospaced);
+    font-size: 12px;
+    color: var(--color-midnight-35);
+    white-space: nowrap;
+  }
+
+  &__per-page-option {
+    font-family: var(--font-monospaced);
+    font-size: 12px;
+    padding: 2px 8px;
+    border: 1px solid var(--color-midnight-25);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--color-midnight-35);
+    cursor: pointer;
+    line-height: 1.5;
+
+    &:hover {
+      border-color: var(--color-fire);
+      color: var(--color-fire);
+    }
+
+    &--active {
+      border-color: var(--color-fire);
+      color: var(--color-fire);
+      font-weight: 700;
+    }
   }
 
   &__blank-state {

--- a/src/components/SearchNamesPanel.vue
+++ b/src/components/SearchNamesPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="namesResults"
       @prev-clicked="loadPrevNames"
       @next-clicked="loadNextNames">
@@ -14,6 +15,12 @@ const { namesResults } = storeToRefs(useSearchStore())
 const { fetchNamesResults } = useSearchStore()
 
 const route = useRoute()
+
+const pageLimit = usePageLimit('search-names')
+
+watch(pageLimit, () => {
+  fetchNamesResults({ query: route.params.id, limit: pageLimit.value })
+})
 
 fetchNamesResults({ query: route.params.id })
 

--- a/src/components/SearchNftsPanel.vue
+++ b/src/components/SearchNftsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="nftsResults"
       @prev-clicked="loadPrevNfts"
       @next-clicked="loadNextNfts">
@@ -14,6 +15,12 @@ const { nftsResults } = storeToRefs(useSearchStore())
 const { fetchNftsResults } = useSearchStore()
 
 const route = useRoute()
+
+const pageLimit = usePageLimit('search-nfts')
+
+watch(pageLimit, () => {
+  fetchNftsResults({ query: route.params.id, limit: pageLimit.value })
+})
 
 fetchNftsResults({ query: route.params.id })
 

--- a/src/components/SearchTokensPanel.vue
+++ b/src/components/SearchTokensPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel>
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="tokensResults"
       @prev-clicked="loadPrevTokens"
       @next-clicked="loadNextTokens">
@@ -14,6 +15,12 @@ const { tokensResults } = storeToRefs(useSearchStore())
 const { fetchTokenResults } = useSearchStore()
 
 const route = useRoute()
+
+const pageLimit = usePageLimit('search-tokens')
+
+watch(pageLimit, () => {
+  fetchTokenResults({ query: route.params.id, limit: pageLimit.value })
+})
 
 fetchTokenResults({ query: route.params.id })
 

--- a/src/components/StateChannelTransactionsPanel.vue
+++ b/src/components/StateChannelTransactionsPanel.vue
@@ -3,6 +3,7 @@
     v-if="stateChannelTransactions"
     class="state-channel-transactions-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :total-count="stateChannelTransactions.count"
       :entities="stateChannelTransactions"
       pagination-style="history"
@@ -19,15 +20,21 @@ const { fetchStateChannelTransactions } = useStateChannelDetailsStore()
 
 const route = useRoute()
 
+const pageLimit = usePageLimit('state-channel-transactions')
+
+watch(pageLimit, () => {
+  fetchStateChannelTransactions({ id: route.params.id, limit: pageLimit.value })
+})
+
 function loadPrevTransactions() {
-  fetchStateChannelTransactions(stateChannelTransactions.value.prev)
+  fetchStateChannelTransactions({ queryParameters: stateChannelTransactions.value.prev })
 }
 
 function loadNextTransactions() {
-  fetchStateChannelTransactions(stateChannelTransactions.value.next)
+  fetchStateChannelTransactions({ queryParameters: stateChannelTransactions.value.next })
 }
 
 if (import.meta.client) {
-  fetchStateChannelTransactions({ id: route.params.id })
+  fetchStateChannelTransactions({ id: route.params.id, limit: pageLimit.value })
 }
 </script>

--- a/src/components/StateChannelsPanel.vue
+++ b/src/components/StateChannelsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="state-channels-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="stateChannels"
       pagination-style="history"
       :total-count="stateChannelsCount"
@@ -15,16 +16,22 @@
 const { stateChannels, stateChannelsCount } = storeToRefs(useStateChannelsStore())
 const { fetchStateChannels, fetchStateChannelsCount } = useStateChannelsStore()
 
+const pageLimit = usePageLimit('state-channels')
+
+watch(pageLimit, () => {
+  loadStateChannels()
+})
+
 async function loadPrevStateChannels() {
-  await fetchStateChannels(stateChannels.value.prev)
+  await fetchStateChannels({ queryParameters: stateChannels.value.prev })
 }
 
 async function loadNextStateChannels() {
-  await fetchStateChannels(stateChannels.value.next)
+  await fetchStateChannels({ queryParameters: stateChannels.value.next })
 }
 
 async function loadStateChannels() {
-  await fetchStateChannels()
+  await fetchStateChannels({ limit: pageLimit.value })
 }
 
 fetchStateChannelsCount()

--- a/src/components/TokenEventsPanel.vue
+++ b/src/components/TokenEventsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="token-events-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="tokenEvents"
       pagination-style="history"
       :total-count="tokenEventsCount"
@@ -20,6 +21,12 @@ const { fetchTokenEvents } = useTokenDetailsStore()
 
 const route = useRoute()
 
+const pageLimit = usePageLimit('token-events')
+
+watch(pageLimit, () => {
+  fetchTokenEvents({ contractId: route.params.id, limit: pageLimit.value })
+})
+
 function loadPrevEvents() {
   fetchTokenEvents({ queryParameters: tokenEvents.value.prev.substring(3) })
 }
@@ -31,6 +38,7 @@ function loadNextEvents() {
 if (import.meta.client) {
   fetchTokenEvents({
     contractId: route.params.id,
+    limit: pageLimit.value,
   })
 }
 </script>

--- a/src/components/TokenHoldersPanel.vue
+++ b/src/components/TokenHoldersPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="token-holders-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="tokenHolders"
       :total-count="tokenHoldersCount"
       @prev-clicked="loadPrevHolders"
@@ -17,16 +18,22 @@
 const { fetchTokenHolders, fetchTokenHoldersCount } = useTokenDetailsStore()
 const { tokenHolders, tokenDetails, tokenHoldersCount } = storeToRefs(useTokenDetailsStore())
 
+const pageLimit = usePageLimit('token-holders')
+
+watch(pageLimit, () => {
+  fetchTokenHolders({ limit: pageLimit.value })
+})
+
 function loadPrevHolders() {
-  fetchTokenHolders(tokenHolders.value.prev.substring(3))
+  fetchTokenHolders({ queryParameters: tokenHolders.value.prev.substring(3) })
 }
 
 function loadNextHolders() {
-  fetchTokenHolders(tokenHolders.value.next.substring(3))
+  fetchTokenHolders({ queryParameters: tokenHolders.value.next.substring(3) })
 }
 
 if (import.meta.client) {
-  fetchTokenHolders()
+  fetchTokenHolders({ limit: pageLimit.value })
   fetchTokenHoldersCount()
 }
 </script>

--- a/src/components/TokenTradesPanel.vue
+++ b/src/components/TokenTradesPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="token-trades-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       :entities="tokenTrades"
       pagination-style="history"
       @prev-clicked="loadPrevTrades"
@@ -16,6 +17,12 @@ const { fetchTokenTrades } = useTokenDetailsStore()
 
 const route = useRoute()
 
+const pageLimit = usePageLimit('token-trades')
+
+watch(pageLimit, () => {
+  fetchTokenTrades({ contractId: route.params.id, limit: pageLimit.value })
+})
+
 function loadPrevTrades() {
   fetchTokenTrades({ queryParameters: tokenTrades.value.prev.substring(3) })
 }
@@ -27,6 +34,7 @@ function loadNextTrades() {
 if (import.meta.client) {
   fetchTokenTrades({
     contractId: route.params.id,
+    limit: pageLimit.value,
   })
 }
 </script>

--- a/src/components/TokensPanel.vue
+++ b/src/components/TokensPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="tokens-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       v-model:page-index="pageIndex"
       :entities="selectedTokens"
       :total-count="selectedTokensCount"
@@ -27,13 +28,14 @@ const { fetchTokens, fetchTokensCount } = useTokensStore()
 const featureFlags = useFeatureFlags()
 
 const pageIndex = ref(1)
+const pageLimit = usePageLimit('tokens')
 
 async function loadPrevTokens() {
-  await fetchTokens(selectedTokens.value.prev.substring(3))
+  await fetchTokens({ queryParameters: selectedTokens.value.prev.substring(3) })
 }
 
 async function loadNextTokens() {
-  await fetchTokens(selectedTokens.value.next.substring(3))
+  await fetchTokens({ queryParameters: selectedTokens.value.next.substring(3) })
 }
 
 const hasTokenSelect = computed(() => {
@@ -48,9 +50,13 @@ useAsyncData(async () => {
 if (import.meta.client) {
   watch(selectedTokenName, async () => {
     pageIndex.value = 1
-    await fetchTokens('/aex9?by=creation&direction=backward&limit=10')
+    await fetchTokens({ queryParameters: `/aex9?by=creation&direction=backward&limit=${pageLimit.value}` })
   }, {
     immediate: true,
+  })
+  watch(pageLimit, async () => {
+    pageIndex.value = 1
+    await fetchTokens({ queryParameters: `/aex9?by=creation&direction=backward&limit=${pageLimit.value}` })
   })
 }
 </script>

--- a/src/components/TransactionsPanel.vue
+++ b/src/components/TransactionsPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <app-panel class="transactions-panel">
     <paginated-content
+      v-model:limit="pageLimit"
       v-model:page-index="pageIndex"
       pagination-style="history"
       :entities="transactions"
@@ -37,10 +38,11 @@ const {
 const route = useRoute()
 
 const pageIndex = ref(1)
+const pageLimit = usePageLimit('transactions')
 
 if (import.meta.client) {
   if (!isHydrated?.value) {
-    setPageLimit(10)
+    setPageLimit(pageLimit.value)
     loadTransactions()
   }
 
@@ -50,6 +52,12 @@ if (import.meta.client) {
 
   watch(() => route.fullPath, async () => {
     await loadTransactions()
+    pageIndex.value = 1
+  })
+
+  watch(pageLimit, () => {
+    setPageLimit(pageLimit.value)
+    loadTransactions()
     pageIndex.value = 1
   })
 }

--- a/src/composables/accountDetails.js
+++ b/src/composables/accountDetails.js
@@ -99,16 +99,18 @@ export const useAccountStore = defineStore('account', () => {
     totalAccountTransactionsCount.value = data
   }
 
-  async function fetchAccountNames({ accountId, queryParameters } = {}) {
+  async function fetchAccountNames({ accountId, queryParameters, limit } = {}) {
     rawAccountNames.value = null
-    const defaultParameters = `/names?owned_by=${accountId}&by=name&direction=forward&state=active&limit=10`
+    const effectiveLimit = limit || 10
+    const defaultParameters = `/names?owned_by=${accountId}&by=name&direction=forward&state=active&limit=${effectiveLimit}`
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawAccountNames.value = data
   }
 
-  async function fetchAccountTokens({ accountId, queryParameters } = {}) {
+  async function fetchAccountTokens({ accountId, queryParameters, limit } = {}) {
     rawAccountTokens.value = null
-    const defaultParameters = `/accounts/${accountId}/aex9/balances?limit=10`
+    const effectiveLimit = limit || 10
+    const defaultParameters = `/accounts/${accountId}/aex9/balances?limit=${effectiveLimit}`
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawAccountTokens.value = data
 
@@ -133,14 +135,15 @@ export const useAccountStore = defineStore('account', () => {
     )
   }
 
-  async function fetchAccountActivities({ accountId, queryParameters } = {}) {
+  async function fetchAccountActivities({ accountId, queryParameters, limit } = {}) {
     rawAccountActivities.value = null
-    const defaultParameters = `/accounts/${accountId}/activities?limit=10`
+    const effectiveLimit = limit || 10
+    const defaultParameters = `/accounts/${accountId}/activities?limit=${effectiveLimit}`
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawAccountActivities.value = data
   }
 
-  async function fetchAccountTransactions({ accountId, type, queryParameters } = {}) {
+  async function fetchAccountTransactions({ accountId, type, queryParameters, limit } = {}) {
     rawAccountTransactions.value = null
 
     if (queryParameters) {
@@ -151,7 +154,7 @@ export const useAccountStore = defineStore('account', () => {
 
     const transactionsUrl = new URL(`${MIDDLEWARE_URL}/transactions`)
     transactionsUrl.searchParams.append('direction', 'backward')
-    transactionsUrl.searchParams.append('limit', 10)
+    transactionsUrl.searchParams.append('limit', limit || 10)
 
     if (accountId) {
       transactionsUrl.searchParams.append('sender_id', accountId)

--- a/src/composables/contractDetails.js
+++ b/src/composables/contractDetails.js
@@ -87,14 +87,15 @@ export const useContractDetailsStore = defineStore('contractDetails', () => {
     contractAccountBalance.value = data.balance
   }
 
-  async function fetchContractEvents(queryParameters) {
+  async function fetchContractEvents({ queryParameters, limit } = {}) {
     rawContractEvents.value = null
-    const defaultParameters = `/contracts/logs?contract_id=${contractId.value}&aexn-args=true`
+    const effectiveLimit = limit || 10
+    const defaultParameters = `/contracts/logs?contract_id=${contractId.value}&aexn-args=true&limit=${effectiveLimit}`
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawContractEvents.value = data
   }
 
-  async function fetchContractCallTransactions({ queryParameters } = {}) {
+  async function fetchContractCallTransactions({ queryParameters, limit } = {}) {
     rawContractCallTransactions.value = null
 
     if (queryParameters) {
@@ -105,7 +106,7 @@ export const useContractDetailsStore = defineStore('contractDetails', () => {
 
     const transactionsUrl = new URL(`${MIDDLEWARE_URL}/transactions`)
     transactionsUrl.searchParams.append('direction', 'backward')
-    transactionsUrl.searchParams.append('limit', 10)
+    transactionsUrl.searchParams.append('limit', limit || 10)
     transactionsUrl.searchParams.append('type', 'contract_call')
     transactionsUrl.searchParams.append('contract', contractId.value)
 

--- a/src/composables/contracts.js
+++ b/src/composables/contracts.js
@@ -15,8 +15,10 @@ export const useContractsStore = defineStore('contracts', () => {
       : null,
   )
 
-  async function fetchContracts(queryParameters = null) {
-    const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters.substring(3) || '/transactions?type=contract_create&limit=10'}`)
+  async function fetchContracts({ queryParameters, limit } = {}) {
+    const effectiveLimit = limit || 10
+    const defaultUrl = `/transactions?type=contract_create&limit=${effectiveLimit}`
+    const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters ? queryParameters.substring(3) : defaultUrl}`)
     const verifiedContracts = await fetchVerifiedContracts(data)
     if (verifiedContracts) {
       data.data.forEach((contract) => {

--- a/src/composables/dexTrades.js
+++ b/src/composables/dexTrades.js
@@ -12,9 +12,10 @@ export const useDexTradesStore = defineStore('dexTrades', () => {
     : null,
   )
 
-  async function fetchDexTrades(queryParameters) {
+  async function fetchDexTrades({ queryParameters, limit } = {}) {
     rawTrades.value = null
-    const defaultParameters = '/dex/swaps?limit=10'
+    const effectiveLimit = limit || 10
+    const defaultParameters = `/dex/swaps?limit=${effectiveLimit}`
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawTrades.value = data
   }

--- a/src/composables/keyblockDetails.js
+++ b/src/composables/keyblockDetails.js
@@ -19,17 +19,17 @@ export const useKeyblockDetailsStore = defineStore('keyblockDetails', () => {
     }
   }
 
-  async function fetchKeyblockMicroblocks({ queryParameters, microblockHash, id } = {}) {
+  async function fetchKeyblockMicroblocks({ queryParameters, microblockHash, id, limit } = {}) {
     keyblockMicroblocks.value = null
     keyblockMicroblocks.value = await $fetch('/api/keyblocks/microblocks', {
-      params: { microblockHash, queryParameters, id },
+      params: { microblockHash, queryParameters, id, limit },
     })
   }
 
-  async function fetchKeyblockTransactions({ queryParameters, height, type } = {}) {
+  async function fetchKeyblockTransactions({ queryParameters, height, type, limit } = {}) {
     keyblockTransactions.value = null
     keyblockTransactions.value = await $fetch('/api/keyblocks/transactions', {
-      params: { height, queryParameters, type },
+      params: { height, queryParameters, type, limit },
     })
   }
 

--- a/src/composables/keyblocks.js
+++ b/src/composables/keyblocks.js
@@ -2,10 +2,10 @@ export const useKeyblockStore = defineStore('keyblocks', () => {
   const keyblocks = ref(null)
   const keyblocksCount = ref(null)
 
-  async function fetchKeyblocks(queryParameters) {
+  async function fetchKeyblocks({ queryParameters, limit } = {}) {
     keyblocks.value = null
     const data = await $fetch('/api/keyblocks', {
-      params: { queryParameters },
+      params: { queryParameters, limit },
     })
     keyblocks.value = data
     keyblocksCount.value = data.data[0].block

--- a/src/composables/microblockDetails.js
+++ b/src/composables/microblockDetails.js
@@ -18,11 +18,11 @@ export const useMicroblockDetailsStore = defineStore('microblockDetails', () => 
     }
   }
 
-  async function fetchMicroblockTransactions({ queryParameters, microblockHash, type } = {}) {
+  async function fetchMicroblockTransactions({ queryParameters, microblockHash, type, limit } = {}) {
     microblockTransactions.value = null
     try {
       microblockTransactions.value = await $fetch('/api/microblocks/transactions', {
-        params: { microblockHash, queryParameters, type },
+        params: { microblockHash, queryParameters, type, limit },
       })
     } catch (error) {
       if (error?.statusCode === 404 || error?.status === 404) {

--- a/src/composables/mining.js
+++ b/src/composables/mining.js
@@ -9,10 +9,10 @@ export const useMiningStore = defineStore('mining', () => {
     statistics.value = await $fetch('/api/mining/statistics')
   }
 
-  async function fetchMiners(queryParameters) {
+  async function fetchMiners({ queryParameters, limit } = {}) {
     miners.value = null
     miners.value = await $fetch('/api/mining/miners', {
-      params: { queryParameters },
+      params: { queryParameters, limit },
     })
   }
 

--- a/src/composables/nameDetails.js
+++ b/src/composables/nameDetails.js
@@ -21,12 +21,13 @@ export const useNameDetailsStore = defineStore('nameDetails', () => {
     }
   }
 
-  async function fetchNameHistory({ nameHash, queryParameters }) {
+  async function fetchNameHistory({ nameHash, queryParameters, limit } = {}) {
     nameHistory.value = null
     nameHistory.value = await $fetch('/api/names/history', {
       params: {
         queryParameters,
         id: nameHash,
+        limit,
       },
     })
   }

--- a/src/composables/names.js
+++ b/src/composables/names.js
@@ -14,24 +14,24 @@ export const useNamesStore = defineStore('names', () => {
     ])
   }
 
-  async function fetchActiveNames(queryParameters) {
+  async function fetchActiveNames({ queryParameters, limit } = {}) {
     activeNames.value = null
     activeNames.value = await $fetch('/api/names/active', {
-      params: { queryParameters },
+      params: { queryParameters, limit },
     })
   }
 
-  async function fetchInAuctionNames(queryParameters) {
+  async function fetchInAuctionNames({ queryParameters, limit } = {}) {
     inAuctionNames.value = null
     inAuctionNames.value = await $fetch('/api/names/auctions', {
-      params: { queryParameters },
+      params: { queryParameters, limit },
     })
   }
 
-  async function fetchExpiredNames(queryParameters) {
+  async function fetchExpiredNames({ queryParameters, limit } = {}) {
     expiredNames.value = null
     expiredNames.value = await $fetch('/api/names/expired', {
-      params: { queryParameters },
+      params: { queryParameters, limit },
     })
   }
 

--- a/src/composables/nftDetails.js
+++ b/src/composables/nftDetails.js
@@ -19,27 +19,31 @@ export const useNftDetailsStore = defineStore('nftDetails', () => {
 
   async function fetchNft(id) {
     nftDetails.value = null
-    nftDetails.value = await $fetch(`/api/nfts/${id}`)
+    const data = await $fetch(`/api/nfts/${id}`)
+    if (data.error) {
+      throw createError({ statusCode: data.error })
+    }
+    nftDetails.value = data
   }
 
-  async function fetchNftInventory({ id, queryParameters }) {
+  async function fetchNftInventory({ id, queryParameters, limit } = {}) {
     nftInventory.value = null
     nftInventory.value = await $fetch('/api/nfts/inventory', {
-      params: { id, queryParameters },
+      params: { id, queryParameters, limit },
     })
   }
 
-  async function fetchNftOwners({ id, queryParameters }) {
+  async function fetchNftOwners({ id, queryParameters, limit } = {}) {
     nftOwners.value = null
     nftOwners.value = await $fetch('/api/nfts/owners', {
-      params: { id, queryParameters },
+      params: { id, queryParameters, limit },
     })
   }
 
-  async function fetchNftTransfers({ id, queryParameters }) {
+  async function fetchNftTransfers({ id, queryParameters, limit } = {}) {
     nftTransfers.value = null
     nftTransfers.value = await $fetch('/api/nfts/transfers', {
-      params: { id, queryParameters },
+      params: { id, queryParameters, limit },
     })
   }
 

--- a/src/composables/nfts.js
+++ b/src/composables/nfts.js
@@ -1,10 +1,10 @@
 export const useNftsStore = defineStore('nfts', () => {
   const nfts = ref(null)
 
-  async function fetchNfts(queryParameters) {
+  async function fetchNfts({ queryParameters, limit } = {}) {
     nfts.value = null
     nfts.value = await $fetch('/api/nfts', {
-      params: { queryParameters },
+      params: { queryParameters, limit },
     })
   }
 

--- a/src/composables/oracleDetails.js
+++ b/src/composables/oracleDetails.js
@@ -3,16 +3,21 @@ export const useOracleDetailsStore = defineStore('oracleDetails', () => {
   const oracleEvents = ref(null)
 
   async function fetchOracleDetails(id) {
-    oracleDetails.value = await $fetch(`/api/oracles/${id}`)
+    const data = await $fetch(`/api/oracles/${id}`)
+    if (data.error) {
+      throw createError({ statusCode: data.error })
+    }
+    oracleDetails.value = data
     return true
   }
 
-  async function fetchOracleEvents({ id, queryParameters = null }) {
+  async function fetchOracleEvents({ id, queryParameters = null, limit = null } = {}) {
     oracleEvents.value = null
     oracleEvents.value = await $fetch('/api/oracles/events', {
       params: {
         queryParameters,
         id,
+        limit,
       },
     })
   }

--- a/src/composables/oracles.js
+++ b/src/composables/oracles.js
@@ -2,12 +2,13 @@ export const useOraclesStore = defineStore('oracles', () => {
   const oracles = ref(null)
   const oraclesCount = ref(null)
 
-  async function fetchOracles({ queryParameters = null, state = null }) {
+  async function fetchOracles({ queryParameters = null, state = null, limit = null } = {}) {
     oracles.value = null
     oracles.value = await $fetch('/api/oracles', {
       params: {
         queryParameters,
         state,
+        limit,
       },
     })
   }

--- a/src/composables/pageLimit.js
+++ b/src/composables/pageLimit.js
@@ -1,0 +1,5 @@
+import { useLocalStorage } from '@vueuse/core'
+
+export function usePageLimit(tableKey) {
+  return useLocalStorage(`aescan-page-limit-${tableKey}`, PAGINATION_LIMIT)
+}

--- a/src/composables/search.js
+++ b/src/composables/search.js
@@ -10,17 +10,17 @@ export const useSearchStore = defineStore('search', () => {
     })
   }
 
-  async function fetchTokenResults({ query, queryParameters } = {}) {
+  async function fetchTokenResults({ query, queryParameters, limit } = {}) {
     tokensResults.value = null
     tokensResults.value = await $fetch('/api/search/tokens', {
-      params: { query, queryParameters },
+      params: { query, queryParameters, limit },
     })
   }
 
-  async function fetchNftsResults({ query, queryParameters } = {}) {
+  async function fetchNftsResults({ query, queryParameters, limit } = {}) {
     nftsResults.value = null
     nftsResults.value = await $fetch('/api/search/nfts', {
-      params: { query, queryParameters },
+      params: { query, queryParameters, limit },
     })
   }
 

--- a/src/composables/stateChannelDetails.js
+++ b/src/composables/stateChannelDetails.js
@@ -19,10 +19,10 @@ export const useStateChannelDetailsStore = defineStore('stateChannelDetails', ()
     }
   }
 
-  async function fetchStateChannelTransactions({ id, queryParameters } = {}) {
+  async function fetchStateChannelTransactions({ id, queryParameters, limit } = {}) {
     stateChannelTransactions.value = null
     stateChannelTransactions.value = await $fetch('/api/channels/transactions', {
-      params: { queryParameters, direction: 'backward', channel: id },
+      params: { queryParameters, direction: 'backward', channel: id, limit },
     })
   }
 

--- a/src/composables/stateChannels.js
+++ b/src/composables/stateChannels.js
@@ -2,10 +2,10 @@ export const useStateChannelsStore = defineStore('stateChannels', () => {
   const stateChannels = ref(null)
   const stateChannelsCount = ref(null)
 
-  async function fetchStateChannels(queryParameters) {
+  async function fetchStateChannels({ queryParameters, limit } = {}) {
     stateChannels.value = null
     stateChannels.value = await $fetch('/api/channels', {
-      params: { queryParameters },
+      params: { queryParameters, limit },
     })
   }
 

--- a/src/composables/tokenDetails.js
+++ b/src/composables/tokenDetails.js
@@ -87,16 +87,18 @@ export const useTokenDetailsStore = defineStore('tokenDetails', () => {
     rawTotalSupply.value = contractCallResult?.decodedResult
   }
 
-  async function fetchTokenEvents({ queryParameters, contractId } = {}) {
+  async function fetchTokenEvents({ queryParameters, contractId, limit } = {}) {
     rawTokenEvents.value = null
-    const defaultParameters = `/contracts/logs?contract=${contractId}&aexn-args=true&limit=10`
+    const effectiveLimit = limit || 10
+    const defaultParameters = `/contracts/logs?contract=${contractId}&aexn-args=true&limit=${effectiveLimit}`
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawTokenEvents.value = data
   }
 
-  async function fetchTokenHolders(queryParameters) {
+  async function fetchTokenHolders({ queryParameters, limit } = {}) {
     rawTokenHolders.value = null
-    const defaultParameters = `/aex9/${tokenId.value}/balances?by=amount&limit=10`
+    const effectiveLimit = limit || 10
+    const defaultParameters = `/aex9/${tokenId.value}/balances?by=amount&limit=${effectiveLimit}`
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawTokenHolders.value = data
   }
@@ -107,9 +109,10 @@ export const useTokenDetailsStore = defineStore('tokenDetails', () => {
     tokenHoldersCount.value = data.holders
   }
 
-  async function fetchTokenTrades({ queryParameters, contractId } = {}) {
+  async function fetchTokenTrades({ queryParameters, contractId, limit } = {}) {
     rawTokenTrades.value = null
-    const defaultParameters = `/dex/${contractId}/swaps?limit=10`
+    const effectiveLimit = limit || 10
+    const defaultParameters = `/dex/${contractId}/swaps?limit=${effectiveLimit}`
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawTokenTrades.value = data
   }

--- a/src/composables/tokens.js
+++ b/src/composables/tokens.js
@@ -30,16 +30,18 @@ export const useTokensStore = defineStore('tokens', () => {
       : null,
   )
 
-  function fetchTokens(queryParameters) {
+  function fetchTokens({ queryParameters, limit } = {}) {
     return Promise.allSettled([
-      fetchAllTokens(queryParameters),
+      fetchAllTokens({ queryParameters, limit }),
       fetchListedTokens(),
     ])
   }
 
-  async function fetchAllTokens(queryParameters = null) {
+  async function fetchAllTokens({ queryParameters, limit } = {}) {
     allTokens.value = null
-    const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || '/aex9?by=name&direction=forward'}`)
+    const effectiveLimit = limit || 10
+    const defaultPath = `/aex9?by=name&direction=forward&limit=${effectiveLimit}`
+    const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultPath}`)
     allTokens.value = data
   }
 

--- a/src/composables/transactions.js
+++ b/src/composables/transactions.js
@@ -70,7 +70,7 @@ export const useTransactionsStore = defineStore('transactions', () => {
 
     const url = new URL(`${MIDDLEWARE_URL}/transactions`)
 
-    url.searchParams.append('limit', limit.value ?? 10)
+    url.searchParams.append('limit', limit ?? 10)
 
     if (scope) {
       url.searchParams.append('scope', scope)

--- a/src/pages/nfts/[id].vue
+++ b/src/pages/nfts/[id].vue
@@ -72,16 +72,14 @@ const activeTabIndex = computed({
 
 try {
   await fetchNftDetails(route.params.id)
-} catch (error) {
-  if ([400, 404].includes(error.response?.status)) {
-    throw showError({
-      data: {
-        entityId: route.params.id,
-        entityName: 'NFT',
-      },
-      statusMessage: 'EntityDetailsNotFound',
-    })
-  }
+} catch {
+  throw showError({
+    data: {
+      entityId: route.params.id,
+      entityName: 'NFT',
+    },
+    statusMessage: 'EntityDetailsNotFound',
+  })
 }
 </script>
 

--- a/src/pages/transactions/[id].vue
+++ b/src/pages/transactions/[id].vue
@@ -48,18 +48,14 @@ const isSyncing = computed(() => isLoading.value || !transactionTypeData.value)
 
 try {
   await fetchTransactionDetails(route.params.id)
-} catch (error) {
-  if ([400, 404].includes(error.response?.status)) {
-    throw showError({
-      data: {
-        entityId: route.params.id,
-        entityName: 'Transaction',
-      },
-      statusMessage: 'EntityDetailsNotFound',
-    })
-  }
-
-  throw error
+} catch {
+  throw showError({
+    data: {
+      entityId: route.params.id,
+      entityName: 'Transaction',
+    },
+    statusMessage: 'EntityDetailsNotFound',
+  })
 }
 
 if (import.meta.client && !transactionTypeData.value) {

--- a/src/server/api/channels/index.js
+++ b/src/server/api/channels/index.js
@@ -4,11 +4,12 @@ import { formatAettosToAe } from '@/utils/format'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { queryParameters } = getQuery(event)
+  const { queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'channels',
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/channels/transactions.js
+++ b/src/server/api/channels/transactions.js
@@ -3,21 +3,22 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { channel, direction, queryParameters } = getQuery(event)
+  const { channel, direction, queryParameters, limit } = getQuery(event)
 
   const [transactions, count] = await Promise.all([
-    fetchStateChannelTransactions(channel, direction, queryParameters),
+    fetchStateChannelTransactions(channel, direction, queryParameters, limit),
     fetchStateChannelTransactionsCount(channel),
   ])
 
   return adaptTransactions(transactions, count)
 })
 
-async function fetchStateChannelTransactions(channel, direction, queryParameters) {
+async function fetchStateChannelTransactions(channel, direction, queryParameters, limit) {
   const url = getUrl({
     entity: 'transactions',
     parameters: { channel, direction },
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
   return data

--- a/src/server/api/keyblocks/index.js
+++ b/src/server/api/keyblocks/index.js
@@ -4,11 +4,12 @@ import { formatAettosToAe } from '@/utils/format'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { queryParameters } = getQuery(event)
+  const { queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'key-blocks',
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
   return adaptKeyblocks(data)

--- a/src/server/api/keyblocks/microblocks.js
+++ b/src/server/api/keyblocks/microblocks.js
@@ -3,12 +3,13 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { id, queryParameters } = getQuery(event)
+  const { id, queryParameters, limit } = getQuery(event)
   const url = getUrl({
     entity: 'key-blocks',
     id,
     route: 'micro-blocks',
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
   return adaptKeyblockMicroblocks(data)

--- a/src/server/api/keyblocks/transactions.js
+++ b/src/server/api/keyblocks/transactions.js
@@ -3,17 +3,17 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { height, queryParameters, type } = getQuery(event)
+  const { height, queryParameters, type, limit } = getQuery(event)
 
   const [data, count] = await Promise.all([
-    fetchTransactions(height, queryParameters, type),
+    fetchTransactions(height, queryParameters, type, limit),
     fetchTransactionsCount(height),
   ])
 
   return adaptTransactions(data, count)
 })
 
-async function fetchTransactions(height, queryParameters, type) {
+async function fetchTransactions(height, queryParameters, type, limit) {
   const url = getUrl({
     entity: 'transactions',
     parameters: {
@@ -21,6 +21,7 @@ async function fetchTransactions(height, queryParameters, type) {
       scope: `gen:${height}-${height}`,
     },
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
   return data

--- a/src/server/api/keyblocks/transactions.js
+++ b/src/server/api/keyblocks/transactions.js
@@ -36,7 +36,7 @@ async function fetchTransactionsCount(height) {
     },
   })
   const { data } = await axios.get(url)
-  return data.data
+  return data
 }
 
 function adaptTransactions(transactions, count) {

--- a/src/server/api/microblocks/transactions.js
+++ b/src/server/api/microblocks/transactions.js
@@ -3,17 +3,17 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { microblockHash, queryParameters, type } = getQuery(event)
+  const { microblockHash, queryParameters, type, limit } = getQuery(event)
 
   const [data, count] = await Promise.all([
-    fetchTransactions(microblockHash, queryParameters, type),
+    fetchTransactions(microblockHash, queryParameters, type, limit),
     fetchTransactionsCount(microblockHash, type),
   ])
 
   return adaptTransactions(data, count)
 })
 
-async function fetchTransactions(microblockHash, queryParameters, type) {
+async function fetchTransactions(microblockHash, queryParameters, type, limit) {
   const url = getUrl({
     entity: 'micro-blocks',
     id: microblockHash,
@@ -22,6 +22,7 @@ async function fetchTransactions(microblockHash, queryParameters, type) {
       type,
     },
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
   return data

--- a/src/server/api/mining/miners.js
+++ b/src/server/api/mining/miners.js
@@ -4,12 +4,13 @@ import { formatAettosToAe } from '@/utils/format'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { queryParameters } = getQuery(event)
+  const { queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'stats/miners',
     parameters: { direction: 'backward' },
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/names/active.js
+++ b/src/server/api/names/active.js
@@ -4,12 +4,13 @@ import { formatAettosToAe } from '@/utils/format'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { queryParameters } = getQuery(event)
+  const { queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'names',
     parameters: { state: 'active', by: 'deactivation', direction: 'forward' },
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
   return adaptActiveNames(data)

--- a/src/server/api/names/auctions.js
+++ b/src/server/api/names/auctions.js
@@ -4,13 +4,14 @@ import { formatAettosToAe } from '@/utils/format'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { queryParameters } = getQuery(event)
+  const { queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'names',
     route: 'auctions',
     parameters: { by: 'expiration', direction: 'forward' },
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
   return adaptInAuctionNames(data)

--- a/src/server/api/names/expired.js
+++ b/src/server/api/names/expired.js
@@ -4,12 +4,13 @@ import { formatAettosToAe } from '@/utils/format'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { queryParameters } = getQuery(event)
+  const { queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'names',
     parameters: { state: 'inactive' },
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/names/history.js
+++ b/src/server/api/names/history.js
@@ -3,13 +3,14 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { id, queryParameters } = getQuery(event)
+  const { id, queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'accounts',
     id,
     route: 'activities',
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
 

--- a/src/server/api/nfts/[id].js
+++ b/src/server/api/nfts/[id].js
@@ -6,13 +6,20 @@ const axios = useAxios()
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')
 
-  const url = getUrl({
-    entity: 'aex141',
-    id,
-  })
+  try {
+    const url = getUrl({
+      entity: 'aex141',
+      id,
+    })
 
-  const { data } = await axios.get(url)
-  return adaptNft(data)
+    const { data } = await axios.get(url)
+    return adaptNft(data)
+  } catch (error) {
+    if ([400, 404].includes(error.response?.status)) {
+      return { error: error.response.status }
+    }
+    throw error
+  }
 })
 
 function adaptNft(nft) {

--- a/src/server/api/nfts/index.js
+++ b/src/server/api/nfts/index.js
@@ -3,20 +3,21 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { queryParameters } = getQuery(event)
+  const { queryParameters, limit } = getQuery(event)
   const [nfts, count] = await Promise.all([
-    fetchNftsList(queryParameters),
+    fetchNftsList(queryParameters, limit),
     fetchNftsCount(),
   ])
 
   return adaptNfts(nfts, count)
 })
 
-async function fetchNftsList(queryParameters) {
+async function fetchNftsList(queryParameters, limit) {
   const url = getUrl({
     entity: 'aex141',
     parameters: { by: 'creation', direction: 'backward' },
     queryParameters,
+    limit,
   })
   const { data } = await axios.get(url)
   return data

--- a/src/server/api/nfts/inventory.js
+++ b/src/server/api/nfts/inventory.js
@@ -3,13 +3,14 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { id, queryParameters } = getQuery(event)
+  const { id, queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'aex141',
     route: 'templates',
     id,
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/nfts/owners.js
+++ b/src/server/api/nfts/owners.js
@@ -3,13 +3,14 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { id, queryParameters } = getQuery(event)
+  const { id, queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'aex141',
     route: 'tokens',
     id,
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/nfts/transfers.js
+++ b/src/server/api/nfts/transfers.js
@@ -3,13 +3,14 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { id, queryParameters } = getQuery(event)
+  const { id, queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'aex141',
     route: 'transfers',
     id,
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/oracles/[id].js
+++ b/src/server/api/oracles/[id].js
@@ -6,13 +6,20 @@ const axios = useAxios()
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')
 
-  const [rawOracle, lastExtendedTx, lastOracleEvent] = await Promise.all([
-    fetchOracle(id),
-    fetchLastExtendedTx(id),
-    fetchLastQueriedTx(id),
-  ])
+  try {
+    const [rawOracle, lastExtendedTx, lastOracleEvent] = await Promise.all([
+      fetchOracle(id),
+      fetchLastExtendedTx(id),
+      fetchLastQueriedTx(id),
+    ])
 
-  return adaptOracleDetails(rawOracle, lastExtendedTx, lastOracleEvent)
+    return adaptOracleDetails(rawOracle, lastExtendedTx, lastOracleEvent)
+  } catch (error) {
+    if ([400, 404].includes(error.response?.status)) {
+      return { error: error.response.status }
+    }
+    throw error
+  }
 })
 
 async function fetchOracle(id) {

--- a/src/server/api/oracles/events.js
+++ b/src/server/api/oracles/events.js
@@ -4,13 +4,14 @@ import { formatAettosToAe, formatDecodeBase64 } from '@/utils/format'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { id, queryParameters } = getQuery(event)
+  const { id, queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'oracles',
     route: 'responses',
     id,
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/oracles/index.js
+++ b/src/server/api/oracles/index.js
@@ -4,12 +4,13 @@ import { formatAettosToAe } from '@/utils/format'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { queryParameters, state } = getQuery(event)
+  const { queryParameters, state, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'oracles',
     parameters: { state },
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/search/names.js
+++ b/src/server/api/search/names.js
@@ -3,12 +3,13 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { query, queryParameters } = getQuery(event)
+  const { query, queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'names',
     parameters: { prefix: query, by: 'name' },
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/search/nfts.js
+++ b/src/server/api/search/nfts.js
@@ -3,12 +3,13 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { query, queryParameters } = getQuery(event)
+  const { query, queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'aex141',
     parameters: { prefix: query, direction: 'forward' },
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/search/tokens.js
+++ b/src/server/api/search/tokens.js
@@ -3,12 +3,13 @@ import useAxios from '@/composables/useAxios'
 const axios = useAxios()
 
 export default defineEventHandler(async (event) => {
-  const { query, queryParameters } = getQuery(event)
+  const { query, queryParameters, limit } = getQuery(event)
 
   const url = getUrl({
     entity: 'aex9',
     parameters: { prefix: query, direction: 'forward' },
     queryParameters,
+    limit,
   })
 
   const { data } = await axios.get(url)

--- a/src/server/api/tokens/ae.js
+++ b/src/server/api/tokens/ae.js
@@ -24,9 +24,13 @@ export default defineEventHandler(async () => {
 async function fetchGate() {
   let marketData = cache.get(CACHE_KEY_GATE_MARKET_DATA)
   if (!marketData) {
-    const response = await $fetch(MARKET_STATS_GATE_ADDRESS)
-    marketData = adaptGate(response)
-    cache.put(CACHE_KEY_GATE_MARKET_DATA, marketData, MARKET_STATS_CACHE_TTL)
+    try {
+      const response = await $fetch(MARKET_STATS_GATE_ADDRESS)
+      marketData = adaptGate(response)
+      cache.put(CACHE_KEY_GATE_MARKET_DATA, marketData, MARKET_STATS_CACHE_TTL)
+    } catch {
+      return null
+    }
   }
   return marketData
 }
@@ -34,9 +38,13 @@ async function fetchGate() {
 async function fetchMexc() {
   let marketData = cache.get(CACHE_KEY_MEXC_MARKET_DATA)
   if (!marketData) {
-    const response = await $fetch(MARKET_STATS_MEXC_ADDRESS)
-    marketData = adaptMexc(response)
-    cache.put(CACHE_KEY_MEXC_MARKET_DATA, marketData, MARKET_STATS_CACHE_TTL)
+    try {
+      const response = await $fetch(MARKET_STATS_MEXC_ADDRESS)
+      marketData = adaptMexc(response)
+      cache.put(CACHE_KEY_MEXC_MARKET_DATA, marketData, MARKET_STATS_CACHE_TTL)
+    } catch {
+      return null
+    }
   }
   return marketData
 }
@@ -44,9 +52,13 @@ async function fetchMexc() {
 async function fetchHotcoin() {
   let marketData = cache.get(CACHE_KEY_HOTCOIN_MARKET_DATA)
   if (!marketData) {
-    const response = await $fetch(MARKET_STATS_HOTCOIN_ADDRESS)
-    marketData = adaptHotCoin(response)
-    cache.put(CACHE_KEY_HOTCOIN_MARKET_DATA, marketData, MARKET_STATS_CACHE_TTL)
+    try {
+      const response = await $fetch(MARKET_STATS_HOTCOIN_ADDRESS)
+      marketData = adaptHotCoin(response)
+      cache.put(CACHE_KEY_HOTCOIN_MARKET_DATA, marketData, MARKET_STATS_CACHE_TTL)
+    } catch {
+      return null
+    }
   }
   return marketData
 }
@@ -54,9 +66,13 @@ async function fetchHotcoin() {
 async function fetchCoinw() {
   let marketData = cache.get(CACHE_KEY_COINW_MARKET_DATA)
   if (!marketData) {
-    const response = await $fetch(MARKET_STATS_COINW_ADDRESS)
-    marketData = adaptCoinW(response)
-    cache.put(CACHE_KEY_COINW_MARKET_DATA, marketData, MARKET_STATS_CACHE_TTL)
+    try {
+      const response = await $fetch(MARKET_STATS_COINW_ADDRESS)
+      marketData = adaptCoinW(response)
+      cache.put(CACHE_KEY_COINW_MARKET_DATA, marketData, MARKET_STATS_CACHE_TTL)
+    } catch {
+      return null
+    }
   }
   return marketData
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -84,6 +84,7 @@ export const CACHE_KEY_COINW_MARKET_DATA = 'coinW-market-data'
 export const CACHE_KEY_PRICE_DATA = 'aeternity-price-data'
 export const VISIBLE_KEYBLOCKS_LIMIT = 20
 export const VISIBLE_TRANSACTIONS_LIMIT = 10
+export const PAGINATION_LIMIT_OPTIONS = [10, 20, 50, 100]
 export const MENU_HASH = '#menu-open'
 
 export const TOKEN_SUPPLY_ACI = [


### PR DESCRIPTION
This pull request introduces configurable pagination limits across multiple panel components in the application. By leveraging a new `usePageLimit` composable, users can now control the number of items displayed per page for various paginated lists. The implementation ensures that data fetching functions reactively update when the page limit changes, resulting in a more dynamic and user-friendly pagination experience. Additionally, there are minor improvements to safely access coin market data.

**Pagination and Data Fetching Improvements:**

* Added support for a reactive `pageLimit` using the `usePageLimit` composable in all major panel components. The `paginated-content` component now uses `v-model:limit="pageLimit"`, and watchers ensure that data is refetched whenever the limit changes. 

**API Parameter Consistency:**

* Refactored API calls to consistently pass parameters as objects (e.g., `{ limit: pageLimit.value }` and `{ queryParameters: ... }`) rather than as raw strings, improving code clarity and maintainability. 

**Coin Market Data Handling:**

* Updated `AeCoinMarketsTable.vue` to safely access nested properties using optional chaining (e.g., `coinMarkets.gate?.price`) to prevent runtime errors if data is missing. 