### PR TITLE
feat: Add price charts to DEX trades page and update price source

### DIFF
--- a/src/components/DexPriceChartPanel.vue
+++ b/src/components/DexPriceChartPanel.vue
@@ -1,0 +1,145 @@
+<template>
+  <app-panel>
+    <template #title>
+      AE DEX PRICE TREND
+    </template>
+
+    <template #end>
+      <price-chart-controls
+        v-model="selectedScope"
+        class="u-hidden-mobile"/>
+    </template>
+
+    <div class="dex-price-chart-panel__line-chart">
+      <template v-if="dexPriceStatistics">
+        <Line
+          v-if="dexPriceStatistics.data.length"
+          :options="chartOptions"
+          :data="chartData"/>
+        <blank-state v-else>
+          No DEX price data available for the selected period
+        </blank-state>
+      </template>
+      <loader-indicator v-else/>
+    </div>
+
+    <price-chart-controls
+      v-model="selectedScope"
+      class="dex-price-chart-panel__controls u-hidden-desktop"/>
+  </app-panel>
+</template>
+
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip,
+} from 'chart.js'
+import { DateTime } from 'luxon'
+
+const selectedScope = ref(PRICE_CHART_SCOPE_PRESETS_OPTIONS[2])
+
+const { dexPriceStatistics } = storeToRefs(useChartsStore())
+const { fetchDexPriceStatistics } = useChartsStore()
+
+const labels = computed(() => {
+  return dexPriceStatistics.value.labels.map((label) => {
+    const format = selectedScope.value.intervalBy !== '1H' ? 'yyyy-MM-dd' : 'yyyy-MM-dd HH:mm'
+    return DateTime.fromMillis(parseInt(label)).toFormat(format)
+  })
+})
+
+await useAsyncData('dex-price-statistics', async () => {
+  await fetchDexPriceStatistics(selectedScope.value.intervalBy)
+  return true
+})
+
+if (import.meta.client) {
+  watch([selectedScope], async () => {
+    await fetchDexPriceStatistics(selectedScope.value.intervalBy)
+  })
+}
+
+const chartData = computed(() => {
+  return {
+    labels: labels.value,
+    datasets: [{
+      data: dexPriceStatistics.value.data,
+      label: null,
+      cubicInterpolationMode: 'monotone',
+      tension: 0.4,
+      borderColor: '#1565c0',
+      backgroundColor: '#1565c0',
+      pointRadius: 3,
+      pointHitRadius: 20,
+    }],
+  }
+})
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      display: false,
+    },
+    tooltip: {
+      tooltip: {
+        position: 'top',
+      },
+      callbacks: {
+        label: value => `$ ${value.formattedValue}`,
+      },
+    },
+  },
+  scales: {
+    y: {
+      border: {
+        display: false,
+      },
+      min: 0,
+      ticks: {
+        callback: value => `$ ${value}`,
+      },
+    },
+    x: {
+      grid: {
+        color: () => 'transparent',
+      },
+    },
+  },
+}
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+)
+</script>
+
+<style scoped>
+.dex-price-chart-panel {
+  &__line-chart {
+    height: 250px;
+    position: relative;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__controls {
+    margin-top: var(--space-4);
+  }
+}
+</style>

--- a/src/components/DexPriceChartPanel.vue
+++ b/src/components/DexPriceChartPanel.vue
@@ -90,9 +90,7 @@ const chartOptions = {
       display: false,
     },
     tooltip: {
-      tooltip: {
-        position: 'top',
-      },
+      position: 'nearest',
       callbacks: {
         label: value => `$ ${value.formattedValue}`,
       },

--- a/src/components/DexTradesPanel.vue
+++ b/src/components/DexTradesPanel.vue
@@ -1,5 +1,8 @@
 <template>
   <app-panel>
+    <template #title>
+      DEX SWAPS
+    </template>
     <paginated-content
       v-model:limit="pageLimit"
       :entities="trades"

--- a/src/components/DexTvlChartPanel.vue
+++ b/src/components/DexTvlChartPanel.vue
@@ -1,0 +1,134 @@
+<template>
+  <app-panel>
+    <template #title>
+      DEX TOTAL VALUE LOCKED
+    </template>
+
+    <template #end>
+      <price-chart-controls
+        v-model="selectedScope"
+        class="u-hidden-mobile"/>
+    </template>
+
+    <div class="dex-tvl-chart-panel__line-chart">
+      <template v-if="dexTvlStatistics">
+        <Line
+          v-if="dexTvlStatistics.data.length"
+          :options="chartOptions"
+          :data="chartData"/>
+        <blank-state v-else>
+          No DEX TVL data available for the selected period
+        </blank-state>
+      </template>
+      <loader-indicator v-else/>
+    </div>
+
+    <price-chart-controls
+      v-model="selectedScope"
+      class="dex-tvl-chart-panel__controls u-hidden-desktop"/>
+  </app-panel>
+</template>
+
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip,
+} from 'chart.js'
+import { DateTime } from 'luxon'
+
+const selectedScope = ref(PRICE_CHART_SCOPE_PRESETS_OPTIONS[2])
+
+const { dexTvlStatistics } = storeToRefs(useChartsStore())
+const { fetchDexTvlStatistics } = useChartsStore()
+
+const labels = computed(() => {
+  return dexTvlStatistics.value.labels.map((label) => {
+    const format = selectedScope.value.intervalBy !== '1H' ? 'yyyy-MM-dd' : 'yyyy-MM-dd HH:mm'
+    return DateTime.fromMillis(parseInt(label)).toFormat(format)
+  })
+})
+
+await useAsyncData('dex-tvl-statistics', async () => {
+  await fetchDexTvlStatistics(selectedScope.value.intervalBy)
+  return true
+})
+
+if (import.meta.client) {
+  watch([selectedScope], async () => {
+    await fetchDexTvlStatistics(selectedScope.value.intervalBy)
+  })
+}
+
+const chartData = computed(() => ({
+  labels: labels.value,
+  datasets: [{
+    data: dexTvlStatistics.value.data,
+    label: null,
+    cubicInterpolationMode: 'monotone',
+    tension: 0.4,
+    borderColor: '#1565c0',
+    backgroundColor: '#1565c0',
+    pointRadius: 3,
+    pointHitRadius: 20,
+  }],
+}))
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: value => `$ ${value.formattedValue}`,
+      },
+    },
+  },
+  scales: {
+    y: {
+      border: { display: false },
+      min: 0,
+      ticks: {
+        callback: value => `$ ${value}`,
+      },
+    },
+    x: {
+      grid: { color: () => 'transparent' },
+    },
+  },
+}
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+)
+</script>
+
+<style scoped>
+.dex-tvl-chart-panel {
+  &__line-chart {
+    height: 250px;
+    position: relative;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__controls {
+    margin-top: var(--space-4);
+  }
+}
+</style>

--- a/src/components/DexVolumeChartPanel.vue
+++ b/src/components/DexVolumeChartPanel.vue
@@ -1,0 +1,128 @@
+<template>
+  <app-panel>
+    <template #title>
+      DEX VOLUME
+    </template>
+
+    <template #end>
+      <price-chart-controls
+        v-model="selectedScope"
+        class="u-hidden-mobile"/>
+    </template>
+
+    <div class="dex-volume-chart-panel__bar-chart">
+      <template v-if="dexVolumeStatistics">
+        <Bar
+          v-if="dexVolumeStatistics.data.length"
+          :options="chartOptions"
+          :data="chartData"/>
+        <blank-state v-else>
+          No DEX volume data available for the selected period
+        </blank-state>
+      </template>
+      <loader-indicator v-else/>
+    </div>
+
+    <price-chart-controls
+      v-model="selectedScope"
+      class="dex-volume-chart-panel__controls u-hidden-desktop"/>
+  </app-panel>
+</template>
+
+<script setup>
+import { Bar } from 'vue-chartjs'
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Title,
+  Tooltip,
+} from 'chart.js'
+import { DateTime } from 'luxon'
+
+const selectedScope = ref(PRICE_CHART_SCOPE_PRESETS_OPTIONS[2])
+
+const { dexVolumeStatistics } = storeToRefs(useChartsStore())
+const { fetchDexVolumeStatistics } = useChartsStore()
+
+const labels = computed(() => {
+  return dexVolumeStatistics.value.labels.map((label) => {
+    const format = selectedScope.value.intervalBy !== '1H' ? 'yyyy-MM-dd' : 'yyyy-MM-dd HH:mm'
+    return DateTime.fromMillis(parseInt(label)).toFormat(format)
+  })
+})
+
+await useAsyncData('dex-volume-statistics', async () => {
+  await fetchDexVolumeStatistics(selectedScope.value.intervalBy)
+  return true
+})
+
+if (import.meta.client) {
+  watch([selectedScope], async () => {
+    await fetchDexVolumeStatistics(selectedScope.value.intervalBy)
+  })
+}
+
+const chartData = computed(() => ({
+  labels: labels.value,
+  datasets: [{
+    data: dexVolumeStatistics.value.data,
+    label: null,
+    backgroundColor: '#1565c0',
+    borderRadius: 3,
+  }],
+}))
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: value => `$ ${value.formattedValue}`,
+      },
+    },
+  },
+  scales: {
+    y: {
+      border: { display: false },
+      min: 0,
+      ticks: {
+        callback: value => `$ ${value}`,
+      },
+    },
+    x: {
+      grid: { color: () => 'transparent' },
+    },
+  },
+}
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+)
+</script>
+
+<style scoped>
+.dex-volume-chart-panel {
+  &__bar-chart {
+    height: 250px;
+    position: relative;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__controls {
+    margin-top: var(--space-4);
+  }
+}
+</style>

--- a/src/composables/charts.js
+++ b/src/composables/charts.js
@@ -12,6 +12,7 @@ export const useChartsStore = defineStore('charts', () => {
   const hashrateStatistics = ref(null)
   const accountsStatistics = ref(null)
   const priceStatistics = ref(null)
+  const dexPriceStatistics = ref(null)
 
   async function fetchTransactionsStatistics(intervalBy, limit, scope, txType) {
     transactionsStatistics.value = null
@@ -112,8 +113,16 @@ export const useChartsStore = defineStore('charts', () => {
     priceStatistics.value = data
   }
 
+  async function fetchDexPriceStatistics(intervalBy) {
+    dexPriceStatistics.value = null
+
+    const { data } = await axios.get(`/api/tokens/ae/dex-price-chart?timeFrame=${intervalBy}`)
+    dexPriceStatistics.value = data
+  }
+
   return {
     priceStatistics,
+    dexPriceStatistics,
     keyblocksStatistics,
     transactionsStatistics,
     contractsStatistics,
@@ -122,6 +131,7 @@ export const useChartsStore = defineStore('charts', () => {
     hashrateStatistics,
     accountsStatistics,
     fetchPriceStatistics,
+    fetchDexPriceStatistics,
     fetchKeyblocksStatistics,
     fetchTransactionsStatistics,
     fetchContractsStatistics,

--- a/src/composables/charts.js
+++ b/src/composables/charts.js
@@ -13,6 +13,8 @@ export const useChartsStore = defineStore('charts', () => {
   const accountsStatistics = ref(null)
   const priceStatistics = ref(null)
   const dexPriceStatistics = ref(null)
+  const dexTvlStatistics = ref(null)
+  const dexVolumeStatistics = ref(null)
 
   async function fetchTransactionsStatistics(intervalBy, limit, scope, txType) {
     transactionsStatistics.value = null
@@ -120,9 +122,25 @@ export const useChartsStore = defineStore('charts', () => {
     dexPriceStatistics.value = data
   }
 
+  async function fetchDexTvlStatistics(intervalBy) {
+    dexTvlStatistics.value = null
+
+    const { data } = await axios.get(`/api/tokens/ae/dex-tvl-chart?timeFrame=${intervalBy}`)
+    dexTvlStatistics.value = data
+  }
+
+  async function fetchDexVolumeStatistics(intervalBy) {
+    dexVolumeStatistics.value = null
+
+    const { data } = await axios.get(`/api/tokens/ae/dex-volume-chart?timeFrame=${intervalBy}`)
+    dexVolumeStatistics.value = data
+  }
+
   return {
     priceStatistics,
     dexPriceStatistics,
+    dexTvlStatistics,
+    dexVolumeStatistics,
     keyblocksStatistics,
     transactionsStatistics,
     contractsStatistics,
@@ -132,6 +150,8 @@ export const useChartsStore = defineStore('charts', () => {
     accountsStatistics,
     fetchPriceStatistics,
     fetchDexPriceStatistics,
+    fetchDexTvlStatistics,
+    fetchDexVolumeStatistics,
     fetchKeyblocksStatistics,
     fetchTransactionsStatistics,
     fetchContractsStatistics,

--- a/src/composables/charts.js
+++ b/src/composables/charts.js
@@ -110,30 +110,22 @@ export const useChartsStore = defineStore('charts', () => {
 
   async function fetchPriceStatistics(intervalBy) {
     priceStatistics.value = null
-
-    const { data } = await axios.get(`/api/tokens/ae/price-chart?timeFrame=${intervalBy}`)
-    priceStatistics.value = data
+    priceStatistics.value = await $fetch(`/api/tokens/ae/price-chart?timeFrame=${encodeURIComponent(intervalBy)}`)
   }
 
   async function fetchDexPriceStatistics(intervalBy) {
     dexPriceStatistics.value = null
-
-    const { data } = await axios.get(`/api/tokens/ae/dex-price-chart?timeFrame=${intervalBy}`)
-    dexPriceStatistics.value = data
+    dexPriceStatistics.value = await $fetch(`/api/tokens/ae/dex-price-chart?timeFrame=${encodeURIComponent(intervalBy)}`)
   }
 
   async function fetchDexTvlStatistics(intervalBy) {
     dexTvlStatistics.value = null
-
-    const { data } = await axios.get(`/api/tokens/ae/dex-tvl-chart?timeFrame=${intervalBy}`)
-    dexTvlStatistics.value = data
+    dexTvlStatistics.value = await $fetch(`/api/tokens/ae/dex-tvl-chart?timeFrame=${encodeURIComponent(intervalBy)}`)
   }
 
   async function fetchDexVolumeStatistics(intervalBy) {
     dexVolumeStatistics.value = null
-
-    const { data } = await axios.get(`/api/tokens/ae/dex-volume-chart?timeFrame=${intervalBy}`)
-    dexVolumeStatistics.value = data
+    dexVolumeStatistics.value = await $fetch(`/api/tokens/ae/dex-volume-chart?timeFrame=${encodeURIComponent(intervalBy)}`)
   }
 
   return {

--- a/src/composables/charts.js
+++ b/src/composables/charts.js
@@ -1,7 +1,7 @@
 import { useRuntimeConfig } from 'nuxt/app'
 
 export const useChartsStore = defineStore('charts', () => {
-  const { MIDDLEWARE_URL, DEX_BACKEND_URL, AE_TOKEN_ID } = useRuntimeConfig().public
+  const { MIDDLEWARE_URL } = useRuntimeConfig().public
   const axios = useAxios()
 
   const transactionsStatistics = ref(null)
@@ -108,11 +108,7 @@ export const useChartsStore = defineStore('charts', () => {
   async function fetchPriceStatistics(intervalBy) {
     priceStatistics.value = null
 
-    const slug = `&timeFrame=${intervalBy}`
-
-    const { data } = await axios.get(
-      `${DEX_BACKEND_URL}/graph?graphType=Price&tokenAddress=${AE_TOKEN_ID}${slug}`,
-    )
+    const { data } = await axios.get(`/api/tokens/ae/price-chart?timeFrame=${intervalBy}`)
     priceStatistics.value = data
   }
 

--- a/src/pages/charts/price.vue
+++ b/src/pages/charts/price.vue
@@ -15,7 +15,6 @@
     </template>
     <template #detail>
       <price-chart-panel/>
-      <dex-price-chart-panel/>
     </template>
   </NuxtLayout>
 </template>

--- a/src/pages/charts/price.vue
+++ b/src/pages/charts/price.vue
@@ -15,6 +15,7 @@
     </template>
     <template #detail>
       <price-chart-panel/>
+      <dex-price-chart-panel/>
     </template>
   </NuxtLayout>
 </template>

--- a/src/pages/dex-trades/index.vue
+++ b/src/pages/dex-trades/index.vue
@@ -10,6 +10,12 @@
     </template>
   </page-header>
 
+  <div class="dex-trades-charts">
+    <dex-price-chart-panel/>
+    <dex-tvl-chart-panel/>
+    <dex-volume-chart-panel/>
+  </div>
+
   <dex-trades-panel v-if="!isLoading"/>
   <loader-panel v-else/>
 </template>
@@ -19,3 +25,12 @@ import { dexTradesHints } from '@/utils/hints/dexTradesHints'
 
 const { isLoading } = useLoading()
 </script>
+
+<style scoped>
+.dex-trades-charts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  margin-bottom: var(--space-6);
+}
+</style>

--- a/src/server/api/tokens/ae/dex-price-chart.js
+++ b/src/server/api/tokens/ae/dex-price-chart.js
@@ -6,8 +6,11 @@ import {
 
 const CACHE_KEY = `${CACHE_KEY_PRICE_DATA}-dex`
 
+const SUPPORTED_TIMEFRAMES = new Set(['1H', '1D', '1W', '1M', '1Y', 'MAX'])
+
 export default defineEventHandler(async (event) => {
-  const { timeFrame = 'MAX' } = getQuery(event)
+  const { timeFrame: rawTimeFrame = 'MAX' } = getQuery(event)
+  const timeFrame = SUPPORTED_TIMEFRAMES.has(rawTimeFrame) ? rawTimeFrame : 'MAX'
   const { DEX_BACKEND_URL, AE_TOKEN_ID } = useRuntimeConfig().public
   const cacheKey = `${CACHE_KEY}-${timeFrame}`
 
@@ -18,9 +21,11 @@ export default defineEventHandler(async (event) => {
   let result = cache.get(cacheKey)
   if (!result) {
     try {
-      const response = await $fetch(
-        `${DEX_BACKEND_URL}/graph?graphType=Price&tokenAddress=${AE_TOKEN_ID}&timeFrame=${timeFrame}`,
-      )
+      const url = new URL(`${DEX_BACKEND_URL}/graph`)
+      url.searchParams.set('graphType', 'Price')
+      url.searchParams.set('tokenAddress', AE_TOKEN_ID)
+      url.searchParams.set('timeFrame', timeFrame)
+      const response = await $fetch(url.toString())
       result = {
         labels: response.labels ?? [],
         data: (response.data ?? []).map(Number),

--- a/src/server/api/tokens/ae/dex-price-chart.js
+++ b/src/server/api/tokens/ae/dex-price-chart.js
@@ -1,0 +1,35 @@
+import cache from 'memory-cache'
+import {
+  CACHE_KEY_PRICE_DATA,
+  MARKET_STATS_CACHE_TTL,
+} from '@/utils/constants'
+
+const CACHE_KEY = `${CACHE_KEY_PRICE_DATA}-dex`
+
+export default defineEventHandler(async (event) => {
+  const { timeFrame = 'MAX' } = getQuery(event)
+  const { DEX_BACKEND_URL, AE_TOKEN_ID } = useRuntimeConfig().public
+  const cacheKey = `${CACHE_KEY}-${timeFrame}`
+
+  if (!DEX_BACKEND_URL || !AE_TOKEN_ID) {
+    return { labels: [], data: [] }
+  }
+
+  let result = cache.get(cacheKey)
+  if (!result) {
+    try {
+      const response = await $fetch(
+        `${DEX_BACKEND_URL}/graph?graphType=Price&tokenAddress=${AE_TOKEN_ID}&timeFrame=${timeFrame}`,
+      )
+      result = {
+        labels: response.labels ?? [],
+        data: (response.data ?? []).map(Number),
+      }
+    } catch {
+      result = { labels: [], data: [] }
+    }
+    cache.put(cacheKey, result, MARKET_STATS_CACHE_TTL)
+  }
+
+  return result
+})

--- a/src/server/api/tokens/ae/dex-tvl-chart.js
+++ b/src/server/api/tokens/ae/dex-tvl-chart.js
@@ -6,8 +6,11 @@ import {
 
 const CACHE_KEY = `${CACHE_KEY_PRICE_DATA}-dex-tvl`
 
+const SUPPORTED_TIMEFRAMES = new Set(['1H', '1D', '1W', '1M', '1Y', 'MAX'])
+
 export default defineEventHandler(async (event) => {
-  const { timeFrame = 'MAX' } = getQuery(event)
+  const { timeFrame: rawTimeFrame = 'MAX' } = getQuery(event)
+  const timeFrame = SUPPORTED_TIMEFRAMES.has(rawTimeFrame) ? rawTimeFrame : 'MAX'
   const { DEX_BACKEND_URL } = useRuntimeConfig().public
   const cacheKey = `${CACHE_KEY}-${timeFrame}`
 
@@ -18,9 +21,10 @@ export default defineEventHandler(async (event) => {
   let result = cache.get(cacheKey)
   if (!result) {
     try {
-      const response = await $fetch(
-        `${DEX_BACKEND_URL}/graph?graphType=TVL&timeFrame=${timeFrame}`,
-      )
+      const url = new URL(`${DEX_BACKEND_URL}/graph`)
+      url.searchParams.set('graphType', 'TVL')
+      url.searchParams.set('timeFrame', timeFrame)
+      const response = await $fetch(url.toString())
       result = {
         labels: response.labels ?? [],
         data: (response.data ?? []).map(Number),

--- a/src/server/api/tokens/ae/dex-tvl-chart.js
+++ b/src/server/api/tokens/ae/dex-tvl-chart.js
@@ -1,0 +1,35 @@
+import cache from 'memory-cache'
+import {
+  CACHE_KEY_PRICE_DATA,
+  MARKET_STATS_CACHE_TTL,
+} from '@/utils/constants'
+
+const CACHE_KEY = `${CACHE_KEY_PRICE_DATA}-dex-tvl`
+
+export default defineEventHandler(async (event) => {
+  const { timeFrame = 'MAX' } = getQuery(event)
+  const { DEX_BACKEND_URL } = useRuntimeConfig().public
+  const cacheKey = `${CACHE_KEY}-${timeFrame}`
+
+  if (!DEX_BACKEND_URL) {
+    return { labels: [], data: [] }
+  }
+
+  let result = cache.get(cacheKey)
+  if (!result) {
+    try {
+      const response = await $fetch(
+        `${DEX_BACKEND_URL}/graph?graphType=TVL&timeFrame=${timeFrame}`,
+      )
+      result = {
+        labels: response.labels ?? [],
+        data: (response.data ?? []).map(Number),
+      }
+    } catch {
+      result = { labels: [], data: [] }
+    }
+    cache.put(cacheKey, result, MARKET_STATS_CACHE_TTL)
+  }
+
+  return result
+})

--- a/src/server/api/tokens/ae/dex-volume-chart.js
+++ b/src/server/api/tokens/ae/dex-volume-chart.js
@@ -6,8 +6,11 @@ import {
 
 const CACHE_KEY = `${CACHE_KEY_PRICE_DATA}-dex-volume`
 
+const SUPPORTED_TIMEFRAMES = new Set(['1H', '1D', '1W', '1M', '1Y', 'MAX'])
+
 export default defineEventHandler(async (event) => {
-  const { timeFrame = 'MAX' } = getQuery(event)
+  const { timeFrame: rawTimeFrame = 'MAX' } = getQuery(event)
+  const timeFrame = SUPPORTED_TIMEFRAMES.has(rawTimeFrame) ? rawTimeFrame : 'MAX'
   const { DEX_BACKEND_URL } = useRuntimeConfig().public
   const cacheKey = `${CACHE_KEY}-${timeFrame}`
 
@@ -18,9 +21,10 @@ export default defineEventHandler(async (event) => {
   let result = cache.get(cacheKey)
   if (!result) {
     try {
-      const response = await $fetch(
-        `${DEX_BACKEND_URL}/graph?graphType=Volume&timeFrame=${timeFrame}`,
-      )
+      const url = new URL(`${DEX_BACKEND_URL}/graph`)
+      url.searchParams.set('graphType', 'Volume')
+      url.searchParams.set('timeFrame', timeFrame)
+      const response = await $fetch(url.toString())
       result = {
         labels: response.labels ?? [],
         data: (response.data ?? []).map(Number),

--- a/src/server/api/tokens/ae/dex-volume-chart.js
+++ b/src/server/api/tokens/ae/dex-volume-chart.js
@@ -1,0 +1,35 @@
+import cache from 'memory-cache'
+import {
+  CACHE_KEY_PRICE_DATA,
+  MARKET_STATS_CACHE_TTL,
+} from '@/utils/constants'
+
+const CACHE_KEY = `${CACHE_KEY_PRICE_DATA}-dex-volume`
+
+export default defineEventHandler(async (event) => {
+  const { timeFrame = 'MAX' } = getQuery(event)
+  const { DEX_BACKEND_URL } = useRuntimeConfig().public
+  const cacheKey = `${CACHE_KEY}-${timeFrame}`
+
+  if (!DEX_BACKEND_URL) {
+    return { labels: [], data: [] }
+  }
+
+  let result = cache.get(cacheKey)
+  if (!result) {
+    try {
+      const response = await $fetch(
+        `${DEX_BACKEND_URL}/graph?graphType=Volume&timeFrame=${timeFrame}`,
+      )
+      result = {
+        labels: response.labels ?? [],
+        data: (response.data ?? []).map(Number),
+      }
+    } catch {
+      result = { labels: [], data: [] }
+    }
+    cache.put(cacheKey, result, MARKET_STATS_CACHE_TTL)
+  }
+
+  return result
+})

--- a/src/server/api/tokens/ae/price-chart.js
+++ b/src/server/api/tokens/ae/price-chart.js
@@ -25,17 +25,22 @@ export default defineEventHandler(async (event) => {
 
   let result = cache.get(cacheKey)
   if (!result) {
-    const allPrices = await $fetch(
-      `${SUPERHERO_API_URL}/coins/aeternity/history?currency=usd&days=${days}`,
-    )
+    try {
+      const url = new URL(`${SUPERHERO_API_URL}/coins/aeternity/history`)
+      url.searchParams.set('currency', 'usd')
+      url.searchParams.set('days', days)
+      const allPrices = await $fetch(url.toString())
 
-    const prices = timeFrame === '1H'
-      ? allPrices.filter(([ts]) => ts >= Date.now() - 60 * 60 * 1000)
-      : allPrices
+      const prices = timeFrame === '1H'
+        ? allPrices.filter(([ts]) => ts >= Date.now() - 60 * 60 * 1000)
+        : allPrices
 
-    result = {
-      labels: prices.map(([ts]) => String(ts)),
-      data: prices.map(([, price]) => price),
+      result = {
+        labels: prices.map(([ts]) => String(ts)),
+        data: prices.map(([, price]) => price),
+      }
+    } catch {
+      result = { labels: [], data: [] }
     }
     cache.put(cacheKey, result, MARKET_STATS_CACHE_TTL)
   }

--- a/src/server/api/tokens/ae/price-chart.js
+++ b/src/server/api/tokens/ae/price-chart.js
@@ -1,0 +1,41 @@
+import cache from 'memory-cache'
+import {
+  CACHE_KEY_PRICE_DATA,
+  MARKET_STATS_CACHE_TTL,
+} from '@/utils/constants'
+
+const SUPERHERO_API_URL = 'https://api.superhero.com/api'
+
+const TIMEFRAME_TO_DAYS = {
+  '1H': '1',
+  '1D': '1',
+  '1W': '7',
+  '1M': '30',
+  '1Y': '365',
+  'MAX': 'max',
+}
+
+export default defineEventHandler(async (event) => {
+  const { timeFrame = 'MAX' } = getQuery(event)
+  const days = TIMEFRAME_TO_DAYS[timeFrame] ?? 'max'
+  const cacheKey = `${CACHE_KEY_PRICE_DATA}-${timeFrame}`
+
+  let result = cache.get(cacheKey)
+  if (!result) {
+    const allPrices = await $fetch(
+      `${SUPERHERO_API_URL}/coins/aeternity/history?currency=usd&days=${days}`,
+    )
+
+    const prices = timeFrame === '1H'
+      ? allPrices.filter(([ts]) => ts >= Date.now() - 60 * 60 * 1000)
+      : allPrices
+
+    result = {
+      labels: prices.map(([ts]) => String(ts)),
+      data: prices.map(([, price]) => price),
+    }
+    cache.put(cacheKey, result, MARKET_STATS_CACHE_TTL)
+  }
+
+  return result
+})

--- a/src/server/api/tokens/ae/price-chart.js
+++ b/src/server/api/tokens/ae/price-chart.js
@@ -16,8 +16,11 @@ const TIMEFRAME_TO_DAYS = {
 }
 
 export default defineEventHandler(async (event) => {
-  const { timeFrame = 'MAX' } = getQuery(event)
-  const days = TIMEFRAME_TO_DAYS[timeFrame] ?? 'max'
+  const { timeFrame: rawTimeFrame = 'MAX' } = getQuery(event)
+  const timeFrame = Object.prototype.hasOwnProperty.call(TIMEFRAME_TO_DAYS, rawTimeFrame)
+    ? rawTimeFrame
+    : 'MAX'
+  const days = TIMEFRAME_TO_DAYS[timeFrame]
   const cacheKey = `${CACHE_KEY_PRICE_DATA}-${timeFrame}`
 
   let result = cache.get(cacheKey)


### PR DESCRIPTION
This pull request introduces a comprehensive set of features and improvements to the DEX statistics section, adding new chart panels for price, TVL (Total Value Locked), and volume, as well as the supporting backend API endpoints and state management. The changes enhance the `dex-trades` page with interactive, up-to-date DEX metrics, and improve data fetching, caching, and display.

**Key changes include:**

### Frontend: New DEX Chart Panels and Integration

* Added three new chart panels—`DexPriceChartPanel.vue`, `DexTvlChartPanel.vue`, and `DexVolumeChartPanel.vue`—to display DEX price trends, TVL, and volume, respectively, using `vue-chartjs` and Chart.js. These panels feature responsive designs, loading states, and time frame controls. [[1]](diffhunk://#diff-0cf59e8f5c092fe681ea3ea70cfeb62e1e40b86dcd65cdd6db97ec10e9e391fbR1-R145) [[2]](diffhunk://#diff-9b4e3ccdba594355324ded88f0c6cc68d40919c43e41868e508637cb6c738557R1-R134) [[3]](diffhunk://#diff-f3e91063841eae91dd65e1fae03445a5869d99ae707fd2f2450a1d22383628ebR1-R128)
* Integrated the new chart panels into the `dex-trades` page, arranging them in a vertical stack above the trades table for better data visibility. [[1]](diffhunk://#diff-7791bab49683e7df34f28d2a547e227537e69d11b7d73dcaa89e573152b628bcR13-R18) [[2]](diffhunk://#diff-7791bab49683e7df34f28d2a547e227537e69d11b7d73dcaa89e573152b628bcR28-R36)
* Updated `DexTradesPanel.vue` to include a titled section for clarity.

### State Management: Chart Data Fetching

* Extended the `useChartsStore` composable to add state and fetching methods for DEX price, TVL, and volume statistics, using new API endpoints and removing unused backend URL variables. [[1]](diffhunk://#diff-a8a2dbb7432d58b01652aefabbb7302d7fb65e6c553ba9e96b39d56a0f1b8014L4-R4) [[2]](diffhunk://#diff-a8a2dbb7432d58b01652aefabbb7302d7fb65e6c553ba9e96b39d56a0f1b8014R15-R17) [[3]](diffhunk://#diff-a8a2dbb7432d58b01652aefabbb7302d7fb65e6c553ba9e96b39d56a0f1b8014L111-R143) [[4]](diffhunk://#diff-a8a2dbb7432d58b01652aefabbb7302d7fb65e6c553ba9e96b39d56a0f1b8014R152-R154)

### Backend: API Endpoints and Caching

* Implemented new API endpoints under `src/server/api/tokens/ae/` for `/dex-price-chart`, `/dex-tvl-chart`, and `/dex-volume-chart`, each fetching data from the DEX backend, formatting it, and caching responses for performance. [[1]](diffhunk://#diff-a16fff993cff5418baecd7ee6e4332bf702aa9a89b8f5c71f82ece16988e40daR1-R35) [[2]](diffhunk://#diff-aa05a55b8543e5b9a376258a8300ed4f11f262485541b5195c14416f927b8721R1-R35) [[3]](diffhunk://#diff-85bce92230c499feafd9598a8be643be16198bf8e402aa0c5506e23cf0c7ae16R1-R35)
* Refactored the `/price-chart` endpoint to fetch from an external API, map time frames, and apply caching.

These changes collectively provide users with a richer, more interactive DEX analytics experience, while ensuring efficient data handling and maintainable code structure.