### PR TITLE
fix: be able to open home page after opening error page

### DIFF
--- a/src/components/AccountActivityTypeCell.vue
+++ b/src/components/AccountActivityTypeCell.vue
@@ -27,7 +27,7 @@ const tx = computed(() => props.activity.payload?.tx)
 const activityType = computed(() => {
   switch (props.activity.type) {
     case 'SpendTxEvent':
-      return currency.value.symbol
+      return currency.value?.symbol
     case 'NamePreclaimTxEvent':
     case 'NameClaimTxEvent':
     case 'NameTransferTxEvent':
@@ -67,7 +67,7 @@ const activityType = computed(() => {
       return 'Wrapped Transaction'
     case 'InternalTransferEvent':
       if (props.activity.payload.kind === 'reward_block') {
-        return currency.value.symbol
+        return currency.value?.symbol
       } else if (
         SH_DEX_CONTRACTS.includes(props.activity.payload.contractId)) {
         return 'SH-DEX'

--- a/src/components/ContractVerifiedPanel.vue
+++ b/src/components/ContractVerifiedPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <app-panel>
+  <app-panel class="contract-verified-panel">
     <template
       v-if="isVerified"
       #title>

--- a/src/components/PriceLabel.vue
+++ b/src/components/PriceLabel.vue
@@ -17,13 +17,13 @@
       <app-link
         v-if="hasLink"
         :to="`/tokens/${contractId}`">
-        {{ currency }}
+        {{ currencySymbol }}
       </app-link>
       <template v-else>
-        {{ currency }}
+        {{ currencySymbol }}
       </template>
       <template #tooltip>
-        {{ price }} {{ currency }}
+        {{ price }} {{ currencySymbol }}
       </template>
     </app-tooltip>
 
@@ -32,9 +32,9 @@
       <app-link
         v-if="hasLink"
         :to="`/tokens/${contractId}`">
-        {{ currency }}
+        {{ currencySymbol }}
       </app-link>
-      <template v-else>{{ currency }}</template>
+      <template v-else>{{ currencySymbol }}</template>
     </span>
   </div>
 </template>
@@ -53,7 +53,7 @@ const props = defineProps({
   },
   currency: {
     type: String,
-    default: () => storeToRefs(useConfigStore()).currency.value.symbol,
+    default: undefined,
   },
   hasIcon: {
     type: Boolean,
@@ -69,6 +69,14 @@ const props = defineProps({
   },
 })
 
+const { currency: nativeCurrency } = storeToRefs(useConfigStore())
+
+// the config store may not be populated yet (e.g. when the app mounts after
+// recovering from an error page), so fall back reactively rather than in a
+// prop default, which Vue evaluates only once
+const currencySymbol = computed(() =>
+  props.currency === undefined ? nativeCurrency.value?.symbol : props.currency,
+)
 const isPriceRounded = computed(() =>
   priceRounded.value !== price.value,
 )


### PR DESCRIPTION
<!--- Ensure the title of the Pull Request follows conventional commits syntax. If it resolves an issue, provide its ID in the scope section. -->

## Description
Config was not present in the props when user first entering the 404 page.

## Demo
In the incognito mode go to the page with not existing transaction this for example: transactions/th_2okTRykAPCBwMc8id9DgNyjruPK266e14AWbXhSeLiU8qxi6PX
then click home page in the header, witness 500 error.
<img width="1375" height="1004" alt="image" src="https://github.com/user-attachments/assets/2d0ddeea-9cd3-4e42-b418-bcf1fc996344" />


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read and followed the [Contributing Guide](../../CONTRIBUTING.md)  
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
