### PR TITLE
Fix null-ref crashes when backend fetch fails

### DIFF
--- a/src/composables/accountDetails.js
+++ b/src/composables/accountDetails.js
@@ -114,7 +114,7 @@ export const useAccountStore = defineStore('account', () => {
     const { data } = await axios.get(`${MIDDLEWARE_URL}${queryParameters || defaultParameters}`)
     rawAccountTokens.value = data
 
-    if (rawAccountTokens.value?.data.length) {
+    if (rawAccountTokens.value?.data?.length) {
       await fetchAccountTokensPrices()
     }
   }

--- a/src/composables/recentBlocks.js
+++ b/src/composables/recentBlocks.js
@@ -57,6 +57,8 @@ export const useRecentBlocksStore = defineStore('recentBlocks', () => {
   /* USER INTERACTION */
 
   async function selectKeyblock(keyblock) {
+    if (!keyblocks.value) return
+
     if (isBlockFirstInSequence(keyblock, keyblocks.value)) {
       rawSelectedKeyblock.value = null
     } else {

--- a/src/composables/tokens.js
+++ b/src/composables/tokens.js
@@ -21,7 +21,7 @@ export const useTokensStore = defineStore('tokens', () => {
       return allTokensCount.value
     }
 
-    return selectedTokenName.value?.key === 'listedTokens' ? listedTokens.value?.data.length : allTokensCount.value
+    return selectedTokenName.value?.key === 'listedTokens' ? listedTokens.value?.data?.length : allTokensCount.value
   })
 
   const listedTokens = computed(() =>


### PR DESCRIPTION
## What
Add null-guards in a few spots that read `.length`/`.data.length` off store refs which can stay `null` when their backing fetch fails.

- `recentBlocks.js`: `selectKeyblock` now bails out early if `keyblocks` hasn't loaded, instead of throwing on `keyblocks.value.length`.
- `accountDetails.js`: guard `rawAccountTokens.value?.data?.length`.
- `tokens.js`: guard `listedTokens.value?.data?.length`.

## Why
Found while investigating a CrashLoopBackOff on the `aehc_demo` deployment: when the upstream node/mdw was down, `initializeStores()` swallows the fetch error and leaves store refs `null`, but downstream code assumed they'd always be populated, causing `[unhandled] [500] Cannot read properties of null (reading 'length')` crashes on top of the expected upstream 502s.