### PR TITLE
fix: transaction subscribe source on websocket reconnect

### DIFF
--- a/src/composables/webSocket.js
+++ b/src/composables/webSocket.js
@@ -55,7 +55,7 @@ export const useWebSocket = defineStore('webSocket', () => {
     }
 
     if (subscribedTransactionId.value) {
-      webSocket.value.send(`{"op":"Subscribe", "source": "node", "payload": "${subscribedTransactionId.value}"}`)
+      webSocket.value.send(`{"op":"Subscribe", "source": "mdw", "payload": "${subscribedTransactionId.value}"}`)
     }
 
     webSocket.value.onmessage = (event) => {


### PR DESCRIPTION
## Description
`useWebSocket`'s reconnect handler (`openWebSocket()`) re-subscribes to a
transaction hash using `source: "node"`, but the live watcher for the same
subscription (`watch(subscribedTransactionId, ...)`) uses `source: "mdw"`.
Only `source: "mdw"` supports subscribing to an arbitrary tx hash payload —
`source: "node"` only handles the `KeyBlocks`/`MicroBlocks` channel names.

So after any websocket reconnect (network blip, backend restart) while a user
is on a transaction detail page, the re-subscription silently goes nowhere —
that transaction's live confirmation update never fires again until a full
page reload.

## Demo
No visual change — this only affects a background websocket subscribe
message sent after reconnect.

## Checklist:
- [x] I have read and followed the Contributing Guide
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
